### PR TITLE
fix the compilation errors in extension with latest PG source

### DIFF
--- a/darwin/cpu_info.c
+++ b/darwin/cpu_info.c
@@ -111,7 +111,7 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	values[Anum_cpu_type] = CStringGetTextDatum(s_cpu_type);
 	values[Anum_logical_processor] = Int32GetDatum(logical_cpu);
 	values[Anum_physical_processor] = Int32GetDatum(physical_cpu);
-	values[Anum_cpu_clock_speed] = Int64GetDatumFast(cpu_frequency);
+	values[Anum_cpu_clock_speed] = UInt64GetDatum(cpu_frequency);
 	values[Anum_l1dcache_size] = Int32GetDatum((int)(l1d_cache_bytes/1024));
 	values[Anum_l1icache_size] = Int32GetDatum((int)(l1i_cache_bytes/1024));
 	values[Anum_l2cache_size] = Int32GetDatum((int)(l2_cache_bytes/1024));

--- a/darwin/cpu_memory_by_process.c
+++ b/darwin/cpu_memory_by_process.c
@@ -183,7 +183,7 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 			memory_usage = (float)((int)(memory_usage * 100 + 0.5))/100;
 			values[Anum_percent_cpu_usage] = Float4GetDatum(cpu_usage);
 			values[Anum_percent_memory_usage] = Float4GetDatum(memory_usage);
-			values[Anum_process_memory_bytes] = Int64GetDatumFast((uint64)rss_memory);
+			values[Anum_process_memory_bytes] = UInt64GetDatum((uint64)rss_memory);
 		}
 		else
 		{

--- a/darwin/cpu_usage_info.c
+++ b/darwin/cpu_usage_info.c
@@ -52,6 +52,7 @@ void ReadCPUUsageStatistics(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	Datum      values[Natts_cpu_usage_stats];
 	bool       nulls[Natts_cpu_usage_stats];
 	struct     cpu_stat first_sample, second_sample;
+        float4     total, user, system, idle, nice;
 
 	memset(nulls, 0, sizeof(nulls));
 
@@ -71,11 +72,11 @@ void ReadCPUUsageStatistics(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		return;
 	}
 
-	float4 total = (float4)(second_sample.total - first_sample.total);
-	float4 user = (float4)(second_sample.user - first_sample.user) / total * 100;
-	float4 system = (float4)(second_sample.system - first_sample.system) / total * 100;
-	float4 idle = (float4)(second_sample.idle - first_sample.idle) / total * 100;
-	float4 nice = (float4)(second_sample.nice - first_sample.nice) / total * 100;
+	total = (float4)(second_sample.total - first_sample.total);
+	user = (float4)(second_sample.user - first_sample.user) / total * 100;
+	system = (float4)(second_sample.system - first_sample.system) / total * 100;
+	idle = (float4)(second_sample.idle - first_sample.idle) / total * 100;
+	nice = (float4)(second_sample.nice - first_sample.nice) / total * 100;
 
 	values[Anum_usermode_normal_process] = Float4GetDatum(user);
 	values[Anum_usermode_niced_process] = Float4GetDatum(nice);

--- a/darwin/disk_info.c
+++ b/darwin/disk_info.c
@@ -99,15 +99,15 @@ void ReadDiskInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	uint64     total_inodes = 0;
 	uint64     used_inodes = 0;
 	uint64     free_inodes = 0;
+        struct statfs *buf;
+        int total_count = 0;
+        int i = 0;
 
 	memset(nulls, 0, sizeof(nulls));
 	memset(file_system, 0, MAXPGPATH);
 	memset(mount_point, 0, MAXPGPATH);
 	memset(file_system_type, 0, MAXPGPATH);
 
-	struct statfs *buf;
-	int total_count = 0;
-	int i = 0;
 	total_count = getmntinfo(&buf, MNT_NOWAIT);
 	for(i = 0; i < total_count; i++)
 	{
@@ -137,12 +137,12 @@ void ReadDiskInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		values[Anum_disk_file_system] = CStringGetTextDatum(file_system);
 		values[Anum_disk_file_system_type] = CStringGetTextDatum(file_system_type);
 		values[Anum_disk_mount_point] = CStringGetTextDatum(mount_point);
-		values[Anum_disk_total_space] = Int64GetDatumFast(total_space_bytes);
-		values[Anum_disk_used_space] = Int64GetDatumFast(used_space_bytes);
-		values[Anum_disk_free_space] = Int64GetDatumFast(available_space_bytes);
-		values[Anum_disk_total_inodes] = Int64GetDatumFast(total_inodes);
-		values[Anum_disk_used_inodes] = Int64GetDatumFast(used_inodes);
-		values[Anum_disk_free_inodes] = Int64GetDatumFast(free_inodes);
+		values[Anum_disk_total_space] = UInt64GetDatum(total_space_bytes);
+		values[Anum_disk_used_space] = UInt64GetDatum(used_space_bytes);
+		values[Anum_disk_free_space] = UInt64GetDatum(available_space_bytes);
+		values[Anum_disk_total_inodes] = UInt64GetDatum(total_inodes);
+		values[Anum_disk_used_inodes] = UInt64GetDatum(used_inodes);
+		values[Anum_disk_free_inodes] = UInt64GetDatum(free_inodes);
 
 		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 

--- a/darwin/memory_info.c
+++ b/darwin/memory_info.c
@@ -32,6 +32,7 @@ void ReadMemoryInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	uint64_t  total;
 	size_t    len = sizeof(total);
 	int       pagesize = getpagesize();
+	mach_port_t mport;
       
 	memset(nulls, 0, sizeof(nulls));
 
@@ -45,7 +46,7 @@ void ReadMemoryInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		return;
 	}
       
-	mach_port_t mport = mach_host_self();
+	mport = mach_host_self();
 
 	/* Read the host memory statistics */
 	ret = host_statistics(mport, HOST_VM_INFO, (host_info_t)&vm_stat, &count);
@@ -69,12 +70,12 @@ void ReadMemoryInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		ereport(DEBUG1, (errmsg("Error while getting swap memory information")));
 	}
 
-	values[Anum_total_memory] = Int64GetDatumFast(total_memory_bytes);
-	values[Anum_used_memory] = Int64GetDatumFast(used_memory_bytes);
-	values[Anum_free_memory] = Int64GetDatumFast(free_memory_bytes);
-	values[Anum_swap_total_memory] = Int64GetDatumFast(swap_mem.xsu_total);
-	values[Anum_swap_used_memory] = Int64GetDatumFast(swap_mem.xsu_used);
-	values[Anum_swap_free_memory] = Int64GetDatumFast(swap_mem.xsu_avail);
+	values[Anum_total_memory] = UInt64GetDatum(total_memory_bytes);
+	values[Anum_used_memory] = UInt64GetDatum(used_memory_bytes);
+	values[Anum_free_memory] = UInt64GetDatum(free_memory_bytes);
+	values[Anum_swap_total_memory] = UInt64GetDatum(swap_mem.xsu_total);
+	values[Anum_swap_used_memory] = UInt64GetDatum(swap_mem.xsu_used);
+	values[Anum_swap_free_memory] = UInt64GetDatum(swap_mem.xsu_avail);
 	nulls[Anum_total_cache_memory] = true;
 	nulls[Anum_kernel_total_memory] = true;
 	nulls[Anum_kernel_paged_memory] = true;

--- a/darwin/network_info.c
+++ b/darwin/network_info.c
@@ -151,15 +151,15 @@ void ReadNetworkInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 
 					values[Anum_net_interface_name] = CStringGetTextDatum(interface_name);
 					values[Anum_net_ipv4_address] = CStringGetTextDatum(ipv4_address);
-					values[Anum_net_speed_mbps] = Int64GetDatumFast(speed_mbps);
-					values[Anum_net_tx_bytes] = Int64GetDatumFast(tx_bytes);
-					values[Anum_net_tx_packets] = Int64GetDatumFast(tx_packets);
-					values[Anum_net_tx_errors] = Int64GetDatumFast(tx_errors);
-					values[Anum_net_tx_dropped] = Int64GetDatumFast(tx_dropped);
-					values[Anum_net_rx_bytes] = Int64GetDatumFast(rx_bytes);
-					values[Anum_net_rx_packets] = Int64GetDatumFast(rx_packets);
-					values[Anum_net_rx_errors] = Int64GetDatumFast(rx_errors);
-					values[Anum_net_rx_dropped] = Int64GetDatumFast(rx_dropped);
+					values[Anum_net_speed_mbps] = UInt64GetDatum(speed_mbps);
+					values[Anum_net_tx_bytes] = UInt64GetDatum(tx_bytes);
+					values[Anum_net_tx_packets] = UInt64GetDatum(tx_packets);
+					values[Anum_net_tx_errors] = UInt64GetDatum(tx_errors);
+					values[Anum_net_tx_dropped] = UInt64GetDatum(tx_dropped);
+					values[Anum_net_rx_bytes] = UInt64GetDatum(rx_bytes);
+					values[Anum_net_rx_packets] = UInt64GetDatum(rx_packets);
+					values[Anum_net_rx_errors] = UInt64GetDatum(rx_errors);
+					values[Anum_net_rx_dropped] = UInt64GetDatum(rx_dropped);
 
 					tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 


### PR DESCRIPTION
Fix the compilation error while building the extension with latest PG source build.
It is getting failed on mac osx with below error

```
darwin/disk_info.c:140:35: error: static_assert failed due to requirement '__builtin_types_compatible_p(unsigned long, long)' "total_space_bytes does not have type int64"
                values[Anum_disk_total_space] = Int64GetDatumFast(total_space_bytes);
                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/postgres.h:550:3: note: expanded from macro 'Int64GetDatumFast'
        (AssertVariableIsOfTypeMacro(X, int64), Int64GetDatum(X))
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:962:3: note: expanded from macro 'AssertVariableIsOfTypeMacro'
        (StaticAssertExpr(__builtin_types_compatible_p(__typeof__(varname), typename), \
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:918:13: note: expanded from macro 'StaticAssertExpr'
        ((void) ({ StaticAssertStmt(condition, errmessage); true; }))
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:916:7: note: expanded from macro 'StaticAssertStmt'
        do { _Static_assert(condition, errmessage); } while(0)
             ^              ~~~~~~~~~
darwin/disk_info.c:141:34: error: static_assert failed due to requirement '__builtin_types_compatible_p(unsigned long, long)' "used_space_bytes does not have type int64"
                values[Anum_disk_used_space] = Int64GetDatumFast(used_space_bytes);
                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/postgres.h:550:3: note: expanded from macro 'Int64GetDatumFast'
        (AssertVariableIsOfTypeMacro(X, int64), Int64GetDatum(X))
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:962:3: note: expanded from macro 'AssertVariableIsOfTypeMacro'
        (StaticAssertExpr(__builtin_types_compatible_p(__typeof__(varname), typename), \
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:918:13: note: expanded from macro 'StaticAssertExpr'
        ((void) ({ StaticAssertStmt(condition, errmessage); true; }))
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:916:7: note: expanded from macro 'StaticAssertStmt'
        do { _Static_assert(condition, errmessage); } while(0)
             ^              ~~~~~~~~~
darwin/disk_info.c:142:34: error: static_assert failed due to requirement '__builtin_types_compatible_p(unsigned long, long)' "available_space_bytes does not have type int64"
                values[Anum_disk_free_space] = Int64GetDatumFast(available_space_bytes);
                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/postgres.h:550:3: note: expanded from macro 'Int64GetDatumFast'
        (AssertVariableIsOfTypeMacro(X, int64), Int64GetDatum(X))
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:962:3: note: expanded from macro 'AssertVariableIsOfTypeMacro'
        (StaticAssertExpr(__builtin_types_compatible_p(__typeof__(varname), typename), \
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:918:13: note: expanded from macro 'StaticAssertExpr'
        ((void) ({ StaticAssertStmt(condition, errmessage); true; }))
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:916:7: note: expanded from macro 'StaticAssertStmt'
        do { _Static_assert(condition, errmessage); } while(0)
             ^              ~~~~~~~~~
darwin/disk_info.c:143:36: error: static_assert failed due to requirement '__builtin_types_compatible_p(unsigned long, long)' "total_inodes does not have type int64"
                values[Anum_disk_total_inodes] = Int64GetDatumFast(total_inodes);
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/postgres.h:550:3: note: expanded from macro 'Int64GetDatumFast'
        (AssertVariableIsOfTypeMacro(X, int64), Int64GetDatum(X))
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:962:3: note: expanded from macro 'AssertVariableIsOfTypeMacro'
        (StaticAssertExpr(__builtin_types_compatible_p(__typeof__(varname), typename), \
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:918:13: note: expanded from macro 'StaticAssertExpr'
        ((void) ({ StaticAssertStmt(condition, errmessage); true; }))
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:916:7: note: expanded from macro 'StaticAssertStmt'
        do { _Static_assert(condition, errmessage); } while(0)
             ^              ~~~~~~~~~
darwin/disk_info.c:144:35: error: static_assert failed due to requirement '__builtin_types_compatible_p(unsigned long, long)' "used_inodes does not have type int64"
                values[Anum_disk_used_inodes] = Int64GetDatumFast(used_inodes);
                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/postgres.h:550:3: note: expanded from macro 'Int64GetDatumFast'
        (AssertVariableIsOfTypeMacro(X, int64), Int64GetDatum(X))
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:962:3: note: expanded from macro 'AssertVariableIsOfTypeMacro'
        (StaticAssertExpr(__builtin_types_compatible_p(__typeof__(varname), typename), \
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:918:13: note: expanded from macro 'StaticAssertExpr'
        ((void) ({ StaticAssertStmt(condition, errmessage); true; }))
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:916:7: note: expanded from macro 'StaticAssertStmt'
        do { _Static_assert(condition, errmessage); } while(0)
             ^              ~~~~~~~~~
darwin/disk_info.c:145:35: error: static_assert failed due to requirement '__builtin_types_compatible_p(unsigned long, long)' "free_inodes does not have type int64"
                values[Anum_disk_free_inodes] = Int64GetDatumFast(free_inodes);
                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/postgres.h:550:3: note: expanded from macro 'Int64GetDatumFast'
        (AssertVariableIsOfTypeMacro(X, int64), Int64GetDatum(X))
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:962:3: note: expanded from macro 'AssertVariableIsOfTypeMacro'
        (StaticAssertExpr(__builtin_types_compatible_p(__typeof__(varname), typename), \
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:918:13: note: expanded from macro 'StaticAssertExpr'
        ((void) ({ StaticAssertStmt(condition, errmessage); true; }))
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/neelpatel/Projects/snapshot-pg/install-pg/include/postgresql/server/c.h:916:7: note: expanded from macro 'StaticAssertStmt'
        do { _Static_assert(condition, errmessage); } while(0)
             ^              ~~~~~~~~~
6 errors generated.
make: *** [darwin/disk_info.o] Error 1

```