### PR TITLE
Fix types so we can compile again.

### DIFF
--- a/linux/cpu_info.c
+++ b/linux/cpu_info.c
@@ -207,7 +207,7 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 			values[Anum_physical_processor] = Int32GetDatum(physical_processor);
 			values[Anum_no_of_cores] = Int32GetDatum(cpu_cores);
 			values[Anum_architecture] = CStringGetTextDatum(architecture);
-			values[Anum_cpu_clock_speed] = Int64GetDatumFast(cpu_freq);
+			values[Anum_cpu_clock_speed] = UInt64GetDatum(cpu_freq);
 			values[Anum_l1dcache_size] = Int32GetDatum(l1dcache_size_kb);
 			values[Anum_l1icache_size] = Int32GetDatum(l1icache_size_kb);
 			values[Anum_l2cache_size] = Int32GetDatum(l2cache_size_kb);

--- a/linux/cpu_memory_by_process.c
+++ b/linux/cpu_memory_by_process.c
@@ -347,8 +347,8 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		values[Anum_process_name] = CStringGetTextDatum(command);
 		values[Anum_percent_cpu_usage] = Float4GetDatum(cpu_usage);
 		values[Anum_percent_memory_usage] = Float4GetDatum(memory_usage);
-		values[Anum_process_memory_bytes] = Int64GetDatumFast((uint64)rss_memory);
-		values[Anum_process_running_since] = Int64GetDatumFast((uint64)(running_since));
+		values[Anum_process_memory_bytes] = UInt64GetDatum((uint64)rss_memory);
+		values[Anum_process_running_since] = UInt64GetDatum((uint64)(running_since));
 
 		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 

--- a/linux/disk_info.c
+++ b/linux/disk_info.c
@@ -164,12 +164,12 @@ void ReadDiskInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 			values[Anum_disk_file_system] = CStringGetTextDatum(file_system);
 			values[Anum_disk_file_system_type] = CStringGetTextDatum(file_system_type);
 			values[Anum_disk_mount_point] = CStringGetTextDatum(mount_point);
-			values[Anum_disk_total_space] = Int64GetDatumFast(total_space_bytes);
-			values[Anum_disk_used_space] = Int64GetDatumFast(used_space_bytes);
-			values[Anum_disk_free_space] = Int64GetDatumFast(available_space_bytes);
-			values[Anum_disk_total_inodes] = Int64GetDatumFast(total_inodes);
-			values[Anum_disk_used_inodes] = Int64GetDatumFast(used_inodes);
-			values[Anum_disk_free_inodes] = Int64GetDatumFast(free_inodes);
+			values[Anum_disk_total_space] = UInt64GetDatum(total_space_bytes);
+			values[Anum_disk_used_space] = UInt64GetDatum(used_space_bytes);
+			values[Anum_disk_free_space] = UInt64GetDatum(available_space_bytes);
+			values[Anum_disk_total_inodes] = UInt64GetDatum(total_inodes);
+			values[Anum_disk_used_inodes] = UInt64GetDatum(used_inodes);
+			values[Anum_disk_free_inodes] = UInt64GetDatum(free_inodes);
 
 			nulls[Anum_disk_drive_letter] = true;
 			nulls[Anum_disk_drive_type] = true;

--- a/linux/io_analysis.c
+++ b/linux/io_analysis.c
@@ -64,12 +64,12 @@ void ReadIOAnalysisInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		  &write_completed, &sector_written, &time_spent_writing_ms);
 
 		values[Anum_device_name] = CStringGetTextDatum(device_name);
-		values[Anum_total_read] = Int64GetDatumFast(read_completed);
-		values[Anum_total_write] = Int64GetDatumFast(write_completed);
-		values[Anum_read_bytes] = Int64GetDatumFast((uint64)(sector_read * sector_size));
-		values[Anum_write_bytes] = Int64GetDatumFast((uint64)(sector_written * sector_size));
-		values[Anum_read_time_ms] = Int64GetDatumFast((uint64)time_spent_reading_ms);
-		values[Anum_write_time_ms] = Int64GetDatumFast((uint64)time_spent_writing_ms);
+		values[Anum_total_read] = UInt64GetDatum(read_completed);
+		values[Anum_total_write] = UInt64GetDatum(write_completed);
+		values[Anum_read_bytes] = UInt64GetDatum((uint64)(sector_read * sector_size));
+		values[Anum_write_bytes] = UInt64GetDatum((uint64)(sector_written * sector_size));
+		values[Anum_read_time_ms] = UInt64GetDatum((uint64)time_spent_reading_ms);
+		values[Anum_write_time_ms] = UInt64GetDatum((uint64)time_spent_writing_ms);
 
 		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 

--- a/linux/memory_info.c
+++ b/linux/memory_info.c
@@ -101,13 +101,13 @@ void ReadMemoryInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		// Check if we get all lines, add as row
 		if (line_count == MEMORY_READ_COUNT)
 		{
-			values[Anum_total_memory] = Int64GetDatumFast(total_memory_bytes);
-			values[Anum_free_memory] = Int64GetDatumFast(free_memory_bytes);
-			values[Anum_used_memory] = Int64GetDatumFast(used_memory_bytes);
-			values[Anum_total_cache_memory] = Int64GetDatumFast(cached_bytes);
-			values[Anum_swap_total_memory] = Int64GetDatumFast(swap_total_bytes);
-			values[Anum_swap_free_memory] = Int64GetDatumFast(swap_free_bytes);
-			values[Anum_swap_used_memory] = Int64GetDatumFast(swap_used_bytes);
+			values[Anum_total_memory] = UInt64GetDatum(total_memory_bytes);
+			values[Anum_free_memory] = UInt64GetDatum(free_memory_bytes);
+			values[Anum_used_memory] = UInt64GetDatum(used_memory_bytes);
+			values[Anum_total_cache_memory] = UInt64GetDatum(cached_bytes);
+			values[Anum_swap_total_memory] = UInt64GetDatum(swap_total_bytes);
+			values[Anum_swap_free_memory] = UInt64GetDatum(swap_free_bytes);
+			values[Anum_swap_used_memory] = UInt64GetDatum(swap_used_bytes);
 
 			/* set the NULL value as it is not for this platform */
 			nulls[Anum_kernel_total_memory] = true;

--- a/linux/network_info.c
+++ b/linux/network_info.c
@@ -199,15 +199,15 @@ void ReadNetworkInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 
 			values[Anum_net_interface_name] = CStringGetTextDatum(interface_name);
 			values[Anum_net_ipv4_address] = CStringGetTextDatum(ipv4_address);
-			values[Anum_net_speed_mbps] = Int64GetDatumFast(speed_mbps);
-			values[Anum_net_tx_bytes] = Int64GetDatumFast(tx_bytes);
-			values[Anum_net_tx_packets] = Int64GetDatumFast(tx_packets);
-			values[Anum_net_tx_errors] = Int64GetDatumFast(tx_errors);
-			values[Anum_net_tx_dropped] = Int64GetDatumFast(tx_dropped);
-			values[Anum_net_rx_bytes] = Int64GetDatumFast(rx_bytes);
-			values[Anum_net_rx_packets] = Int64GetDatumFast(rx_packets);
-			values[Anum_net_rx_errors] = Int64GetDatumFast(rx_errors);
-			values[Anum_net_rx_dropped] = Int64GetDatumFast(rx_dropped);
+			values[Anum_net_speed_mbps] = UInt64GetDatum(speed_mbps);
+			values[Anum_net_tx_bytes] = UInt64GetDatum(tx_bytes);
+			values[Anum_net_tx_packets] = UInt64GetDatum(tx_packets);
+			values[Anum_net_tx_errors] = UInt64GetDatum(tx_errors);
+			values[Anum_net_tx_dropped] = UInt64GetDatum(tx_dropped);
+			values[Anum_net_rx_bytes] = UInt64GetDatum(rx_bytes);
+			values[Anum_net_rx_packets] = UInt64GetDatum(rx_packets);
+			values[Anum_net_rx_errors] = UInt64GetDatum(rx_errors);
+			values[Anum_net_rx_dropped] = UInt64GetDatum(rx_dropped);
 
 			tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 

--- a/windows/cpu_info.c
+++ b/windows/cpu_info.c
@@ -118,7 +118,7 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 			{
 				/* convert MHz to Hz */
 				uint64 max_clock_speed = (uint64)((uint64)(query_result.intVal) * (uint64)1000000);
-				values[Anum_cpu_clock_speed] = Int64GetDatumFast(max_clock_speed);
+				values[Anum_cpu_clock_speed] = UInt64GetDatum(max_clock_speed);
 			}
 
 			hres = result->lpVtbl->Get(result, L"Architecture", 0, &query_result, 0, 0);

--- a/windows/cpu_memory_by_process.c
+++ b/windows/cpu_memory_by_process.c
@@ -102,7 +102,7 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					memset(dst, 0x00, (wstr_length + 10));
 					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
 					long long val = strtoll(dst, NULL, 10);
-					values[Anum_process_running_since] = Int64GetDatumFast(val);
+					values[Anum_process_running_since] = UInt64GetDatum(val);
 					free(dst);
 				}
 			}
@@ -145,7 +145,7 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					memset(dst, 0x00, (wstr_length + 10));
 					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
 					long long val = strtoll(dst, NULL, 10);
-					values[Anum_process_memory_bytes] = Int64GetDatumFast(val);
+					values[Anum_process_memory_bytes] = UInt64GetDatum(val);
 					float4 memory_usage_per = (float4)(val / total_physical_memory) * 100;
 					values[Anum_percent_memory_usage] = Float4GetDatum(memory_usage_per);
 					free(dst);

--- a/windows/disk_info.c
+++ b/windows/disk_info.c
@@ -106,7 +106,7 @@ void ReadDiskInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					memset(dst, 0x00, (wstr_length + 10));
 					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
 					free_space = strtoll(dst, NULL, 10);
-					values[Anum_disk_free_space] = Int64GetDatumFast(free_space);
+					values[Anum_disk_free_space] = UInt64GetDatum(free_space);
 					free(dst);
 				}
 			}
@@ -127,13 +127,13 @@ void ReadDiskInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					memset(dst, 0x00, (wstr_length + 10));
 					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
 					total_space = strtoll(dst, NULL, 10);
-					values[Anum_disk_total_space] = Int64GetDatumFast(total_space);
+					values[Anum_disk_total_space] = UInt64GetDatum(total_space);
 					free(dst);
 				}
 			}
 
 			used_space = (total_space - free_space);
-			values[Anum_disk_used_space] = Int64GetDatumFast(used_space);
+			values[Anum_disk_used_space] = UInt64GetDatum(used_space);
 
 			nulls[Anum_disk_mount_point] = true;
 			nulls[Anum_disk_file_system_type] = true;

--- a/windows/io_analysis.c
+++ b/windows/io_analysis.c
@@ -90,12 +90,12 @@ void ReadIOAnalysisInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		sprintf_s(szDeviceDisplay, MAX_DEVICE_PATH, "PhysicalDrive%i", deviceId);
 
 		values[Anum_device_name] = CStringGetTextDatum(szDeviceDisplay);
-		values[Anum_total_read] = Int64GetDatumFast((uint64)diskPerformance.ReadCount);
-		values[Anum_total_write] = Int64GetDatumFast((uint64)diskPerformance.WriteCount);
-		values[Anum_read_bytes] = Int64GetDatumFast((uint64)(diskPerformance.BytesRead.QuadPart));
-		values[Anum_write_bytes] = Int64GetDatumFast((uint64)(diskPerformance.BytesWritten.QuadPart));
-		values[Anum_read_time_ms] = Int64GetDatumFast((uint64)(diskPerformance.ReadTime.QuadPart) / 10000000);
-		values[Anum_write_time_ms] = Int64GetDatumFast((uint64)(diskPerformance.WriteTime.QuadPart) / 10000000);
+		values[Anum_total_read] = UInt64GetDatum((uint64)diskPerformance.ReadCount);
+		values[Anum_total_write] = UInt64GetDatum((uint64)diskPerformance.WriteCount);
+		values[Anum_read_bytes] = UInt64GetDatum((uint64)(diskPerformance.BytesRead.QuadPart));
+		values[Anum_write_bytes] = UInt64GetDatum((uint64)(diskPerformance.BytesWritten.QuadPart));
+		values[Anum_read_time_ms] = UInt64GetDatum((uint64)(diskPerformance.ReadTime.QuadPart) / 10000000);
+		values[Anum_write_time_ms] = UInt64GetDatum((uint64)(diskPerformance.WriteTime.QuadPart) / 10000000);
 
 		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 

--- a/windows/memory_info.c
+++ b/windows/memory_info.c
@@ -71,15 +71,15 @@ void ReadMemoryInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		kernel_non_paged = ((uint64)(per_statex.KernelNonpaged)) * page_size;
 	}
 
-	values[Anum_total_memory]           = Int64GetDatumFast(total_physical_memory);
-	values[Anum_used_memory]            = Int64GetDatumFast((total_physical_memory - avail_physical_memory));
-	values[Anum_free_memory]            = Int64GetDatumFast(avail_physical_memory);
-	values[Anum_total_cache_memory]     = Int64GetDatumFast(total_system_cache);
-	values[Anum_kernel_total_memory]    = Int64GetDatumFast(kernel_total);
-	values[Anum_kernel_paged_memory]    = Int64GetDatumFast(kernel_paged);
-	values[Anum_kernel_nonpaged_memory] = Int64GetDatumFast(kernel_non_paged);
-	values[Anum_total_page_file]        = Int64GetDatumFast(total_page_file);
-	values[Anum_avail_page_file]        = Int64GetDatumFast(avail_page_file);
+	values[Anum_total_memory]           = UInt64GetDatum(total_physical_memory);
+	values[Anum_used_memory]            = UInt64GetDatum((total_physical_memory - avail_physical_memory));
+	values[Anum_free_memory]            = UInt64GetDatum(avail_physical_memory);
+	values[Anum_total_cache_memory]     = UInt64GetDatum(total_system_cache);
+	values[Anum_kernel_total_memory]    = UInt64GetDatum(kernel_total);
+	values[Anum_kernel_paged_memory]    = UInt64GetDatum(kernel_paged);
+	values[Anum_kernel_nonpaged_memory] = UInt64GetDatum(kernel_non_paged);
+	values[Anum_total_page_file]        = UInt64GetDatum(total_page_file);
+	values[Anum_avail_page_file]        = UInt64GetDatum(avail_page_file);
 
 	/* NULL the value which is not required for this platform */
 	nulls[Anum_swap_total_memory] = true;

--- a/windows/network_info.c
+++ b/windows/network_info.c
@@ -182,14 +182,14 @@ void ReadNetworkInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					}
 
 					values[Anum_net_ipv4_address] = CStringGetTextDatum((char *)(ip_rows + ip_index));
-					values[Anum_net_tx_packets] = Int64GetDatumFast((uint64)(if_row->dwOutUcastPkts + if_row->dwOutNUcastPkts));
-					values[Anum_net_rx_packets] = Int64GetDatumFast((uint64)(if_row->dwInUcastPkts + if_row->dwInNUcastPkts));
-					values[Anum_net_tx_bytes] = Int64GetDatumFast((uint64)if_row->dwOutOctets);
-					values[Anum_net_rx_bytes] = Int64GetDatumFast((uint64)if_row->dwInOctets);
-					values[Anum_net_tx_dropped] = Int64GetDatumFast((uint64)if_row->dwOutDiscards);
-					values[Anum_net_rx_dropped] = Int64GetDatumFast((uint64)if_row->dwInDiscards);
-					values[Anum_net_tx_errors] = Int64GetDatumFast((uint64)if_row->dwOutErrors);
-					values[Anum_net_rx_errors] = Int64GetDatumFast((uint64)if_row->dwInErrors);
+					values[Anum_net_tx_packets] = UInt64GetDatum((uint64)(if_row->dwOutUcastPkts + if_row->dwOutNUcastPkts));
+					values[Anum_net_rx_packets] = UInt64GetDatum((uint64)(if_row->dwInUcastPkts + if_row->dwInNUcastPkts));
+					values[Anum_net_tx_bytes] = UInt64GetDatum((uint64)if_row->dwOutOctets);
+					values[Anum_net_rx_bytes] = UInt64GetDatum((uint64)if_row->dwInOctets);
+					values[Anum_net_tx_dropped] = UInt64GetDatum((uint64)if_row->dwOutDiscards);
+					values[Anum_net_rx_dropped] = UInt64GetDatum((uint64)if_row->dwInDiscards);
+					values[Anum_net_tx_errors] = UInt64GetDatum((uint64)if_row->dwOutErrors);
+					values[Anum_net_rx_errors] = UInt64GetDatum((uint64)if_row->dwInErrors);
 					values[Anum_net_speed_mbps] = Int32GetDatum((int)(if_row->dwSpeed / 1000000));
 
 					tuplestore_putvalues(tupstore, tupdesc, values, nulls);


### PR DESCRIPTION
The compile fix in 40e83e86cb1dedafec50492b1aa2bcdbbe6c6eeb only fixed the GetDatum calls to use the correct types on Darwin. This PR adds the same changes for Linux and Windows.