### PR TITLE
Fix the Makefile for the new version 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ PG_LDFLAGS= -framework IOKit -framework CoreFoundation
 endif
 
 EXTENSION = system_stats
-DATA = system_stats--1.0.sql uninstall_system_stats.sql
+DATA = system_stats--1.0--2.0.sql  system_stats--1.0.sql  system_stats--2.0.sql uninstall_system_stats.sql
 PGFILEDESC = "system_stats - system statistics functions"
 
 


### PR DESCRIPTION
Makefile was missing 2.0 sql file for the installation.

Reported by: @limpus64