### PR TITLE
Remove the redundant logic while reading the CPU stats in windows

### DIFF
--- a/windows/cpu_info.c
+++ b/windows/cpu_info.c
@@ -133,12 +133,6 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				values[Anum_architecture] = CStringGetTextDatum(arch);
 			}
 
-			hres = result->lpVtbl->Get(result, L"MaxClockSpeed", 0, &query_result, 0, 0);
-			if (FAILED(hres))
-				nulls[Anum_l2cache_size] = true;
-			else
-				values[Anum_l2cache_size] = Int32GetDatum(query_result.intVal);
-
 			hres = result->lpVtbl->Get(result, L"L2CacheSize", 0, &query_result, 0, 0);
 			if (FAILED(hres))
 				nulls[Anum_l2cache_size] = true;


### PR DESCRIPTION
Remove the redundant logic of  `MaxClockSpeed` as it already getting read before `L2CacheSize`