### PR TITLE
fix the memory leak in windows

### DIFF
--- a/windows/cpu_info.c
+++ b/windows/cpu_info.c
@@ -63,6 +63,7 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_cpu_description] = CStringGetTextDatum(dst);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"Manufacturer", 0, &query_result, 0, 0);
@@ -83,6 +84,7 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_cpu_vendor] = CStringGetTextDatum(dst);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"Name", 0, &query_result, 0, 0);
@@ -103,13 +105,16 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_model_name] = CStringGetTextDatum(dst);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"ProcessorType", 0, &query_result, 0, 0);
 			if (FAILED(hres))
 				nulls[Anum_processor_type] = true;
-			else
+			else {
 				values[Anum_processor_type] = Int32GetDatum(query_result.intVal);
+				VariantClear(&query_result);
+			}
 
 			hres = result->lpVtbl->Get(result, L"MaxClockSpeed", 0, &query_result, 0, 0);
 			if (FAILED(hres))
@@ -119,6 +124,7 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				/* convert MHz to Hz */
 				uint64 max_clock_speed = (uint64)((uint64)(query_result.intVal) * (uint64)1000000);
 				values[Anum_cpu_clock_speed] = UInt64GetDatum(max_clock_speed);
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"Architecture", 0, &query_result, 0, 0);
@@ -131,6 +137,7 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				memset(arch, 0x00, MAXPGPATH);
 				sprintf(arch, "%d", val);
 				values[Anum_architecture] = CStringGetTextDatum(arch);
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"MaxClockSpeed", 0, &query_result, 0, 0);
@@ -142,26 +149,34 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 			hres = result->lpVtbl->Get(result, L"L2CacheSize", 0, &query_result, 0, 0);
 			if (FAILED(hres))
 				nulls[Anum_l2cache_size] = true;
-			else
+			else {
 				values[Anum_l2cache_size] = Int32GetDatum(query_result.intVal);
+				VariantClear(&query_result);
+			}
 
 			hres = result->lpVtbl->Get(result, L"L3CacheSize", 0, &query_result, 0, 0);
 			if (FAILED(hres))
 				nulls[Anum_l3cache_size] = true;
-			else
+			else {
 				values[Anum_l3cache_size] = Int32GetDatum(query_result.intVal);
+				VariantClear(&query_result);
+			}
 
 			hres = result->lpVtbl->Get(result, L"NumberOfCores", 0, &query_result, 0, 0);
 			if (FAILED(hres))
 				nulls[Anum_no_of_cores] = true;
-			else
+			else {
 				values[Anum_no_of_cores] = Int32GetDatum(query_result.intVal);
+				VariantClear(&query_result);
+			}
 
 			hres = result->lpVtbl->Get(result, L"NumberOfLogicalProcessors", 0, &query_result, 0, 0);
 			if (FAILED(hres))
 				nulls[Anum_logical_processor] = true;
-			else
+			else {
 				values[Anum_logical_processor] = Int32GetDatum(query_result.intVal);
+				VariantClear(&query_result);
+			}
 
 			/* release the current result object */
 			result->lpVtbl->Release(result);

--- a/windows/cpu_memory_by_process.c
+++ b/windows/cpu_memory_by_process.c
@@ -63,8 +63,10 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 			hres = result->lpVtbl->Get(result, L"IDProcess", 0, &query_result, 0, 0);
 			if (FAILED(hres))
 				nulls[Anum_process_pid] = true;
-			else
+			else {
 				values[Anum_process_pid] = Int32GetDatum(query_result.intVal);
+				VariantClear(&query_result);
+			}
 
 			hres = result->lpVtbl->Get(result, L"Name", 0, &query_result, 0, 0);
 			if (FAILED(hres))
@@ -84,6 +86,7 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_process_name] = CStringGetTextDatum(dst);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"ElapsedTime", 0, &query_result, 0, 0);
@@ -105,6 +108,7 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_process_running_since] = UInt64GetDatum(val);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"PercentProcessorTime", 0, &query_result, 0, 0);
@@ -127,6 +131,7 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_percent_cpu_usage] = Float4GetDatum(cpu_usage_per);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"WorkingSetPrivate", 0, &query_result, 0, 0);
@@ -150,6 +155,7 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_percent_memory_usage] = Float4GetDatum(memory_usage_per);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			tuplestore_putvalues(tupstore, tupdesc, values, nulls);

--- a/windows/cpu_usage_info.c
+++ b/windows/cpu_usage_info.c
@@ -62,6 +62,7 @@ void ReadCPUUsageStatistics(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_idle_mode] = Float4GetDatum((float)percent_time);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"PercentInterruptTime", 0, &query_result, 0, 0);
@@ -83,6 +84,7 @@ void ReadCPUUsageStatistics(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_percent_interrupt_time] = Float4GetDatum((float)percent_time);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"PercentPrivilegedTime", 0, &query_result, 0, 0);
@@ -104,6 +106,7 @@ void ReadCPUUsageStatistics(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_percent_privileged_time] = Float4GetDatum((float)percent_time);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"PercentProcessorTime", 0, &query_result, 0, 0);
@@ -125,6 +128,7 @@ void ReadCPUUsageStatistics(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_percent_processor_time] = Float4GetDatum((float)percent_time);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"PercentUserTime", 0, &query_result, 0, 0);
@@ -146,6 +150,7 @@ void ReadCPUUsageStatistics(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_percent_user_time] = Float4GetDatum((float)percent_time);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			nulls[Anum_usermode_normal_process] = true;

--- a/windows/disk_info.c
+++ b/windows/disk_info.c
@@ -62,13 +62,16 @@ void ReadDiskInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_disk_drive_letter] = CStringGetTextDatum(dst);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"DriveType", 0, &query_result, 0, 0);
 			if (FAILED(hres))
 				nulls[Anum_disk_drive_type] = true;
-			else
+			else {
 				values[Anum_disk_drive_type] = Int32GetDatum(query_result.intVal);
+				VariantClear(&query_result);
+			}
 
 			hres = result->lpVtbl->Get(result, L"FileSystem", 0, &query_result, 0, 0);
 			if (FAILED(hres))
@@ -88,6 +91,7 @@ void ReadDiskInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_disk_file_system] = CStringGetTextDatum(dst);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"FreeSpace", 0, &query_result, 0, 0);
@@ -109,6 +113,7 @@ void ReadDiskInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_disk_free_space] = UInt64GetDatum(free_space);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"Capacity", 0, &query_result, 0, 0);
@@ -130,6 +135,7 @@ void ReadDiskInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_disk_total_space] = UInt64GetDatum(total_space);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			used_space = (total_space - free_space);

--- a/windows/os_info.c
+++ b/windows/os_info.c
@@ -83,6 +83,7 @@ void ReadOSInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_os_name] = CStringGetTextDatum(dst);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"Version", 0, &query_result, 0, 0);
@@ -103,6 +104,7 @@ void ReadOSInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_os_version] = CStringGetTextDatum(dst);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"CSName", 0, &query_result, 0, 0);
@@ -123,6 +125,7 @@ void ReadOSInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_host_name] = CStringGetTextDatum(dst);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"OSArchitecture", 0, &query_result, 0, 0);
@@ -143,6 +146,7 @@ void ReadOSInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_os_architecture] = CStringGetTextDatum(dst);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"LastBootUpTime", 0, &query_result, 0, 0);
@@ -163,6 +167,7 @@ void ReadOSInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_os_boot_time] = CStringGetTextDatum(dst);
 					free(dst);
 				}
+				VariantClear(&query_result);
 			}
 
 			values[Anum_os_handle_count] = handle_count;

--- a/windows/process_info.c
+++ b/windows/process_info.c
@@ -57,6 +57,8 @@ void ReadProcessInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					no_of_running_processes++;
 				else
 					no_of_stopped_processes++;
+
+				VariantClear(&query_result);
 			}
 
 			/* release the current result object */

--- a/windows/system_stats_utils.c
+++ b/windows/system_stats_utils.c
@@ -79,6 +79,7 @@ int is_process_running(int pid)
 						ret_val = 1;
 						break;
 					}
+					VariantClear(&query_result);
 				}
 			}
 


### PR DESCRIPTION
Fix the memory leak as per the doc here ( https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-get )

VARIANT type needs to be clear properly.

Reported by @xianglin1998