### PR TITLE
Use of snprintf over sprintf

### DIFF
--- a/darwin/cpu_info.c
+++ b/darwin/cpu_info.c
@@ -97,9 +97,9 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	if (sysctlbyname("hw.machine", machine, &char_size, 0, 0) == -1)
 		nulls[Anum_architecture] = true;
 
-	sprintf(s_byte_order, "%d", byte_order);
-	sprintf(s_cpu_family, "%d", cpu_family);
-	sprintf(s_cpu_type, "%d", cpu_type);
+	snprintf(s_byte_order, MAXPGPATH, "%d", byte_order);
+	snprintf(s_cpu_family, MAXPGPATH, "%d", cpu_family);
+	snprintf(s_cpu_type, MAXPGPATH, "%d", cpu_type);
 
 	nulls[Anum_cpu_vendor] = true;
 	nulls[Anum_cpu_description] = true;

--- a/linux/cpu_info.c
+++ b/linux/cpu_info.c
@@ -195,7 +195,7 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 
 		if (physical_processor)
 		{
-			sprintf(cpu_desc, "%s model %s family %s", vendor_id, model, cpu_family);
+			snprintf(cpu_desc, MAXPGPATH, "%s model %s family %s", vendor_id, model, cpu_family);
 			/* convert CPU frequency from MHz to Hz */
 			cpu_hz = atof(cpu_mhz);
 			cpu_freq = (cpu_hz * 1000000);

--- a/linux/cpu_memory_by_process.c
+++ b/linux/cpu_memory_by_process.c
@@ -237,7 +237,7 @@ void ReadCPUMemoryUsage(int sample)
 		if (!isdigit(*ent->d_name))
 			continue;
 
-		sprintf(file_name,"/proc/%s/stat", ent->d_name);
+		snprintf(file_name, MAXPGPATH, "/proc/%s/stat", ent->d_name);
 
 		fpstat = fopen(file_name, "r");
 		if (fpstat == NULL)

--- a/linux/io_analysis.c
+++ b/linux/io_analysis.c
@@ -37,7 +37,7 @@ void ReadIOAnalysisInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	memset(file_name, 0, MAXPGPATH);
 
 	/* file name used to read the sector size in bytes */
-	sprintf(file_name, "/sys/block/sda/queue/hw_sector_size");
+	snprintf(file_name, MAXPGPATH, "/sys/block/sda/queue/hw_sector_size");
 	ReadFileContent(file_name, &sector_size);
 
 	diskstats_file = fopen(DISK_IO_STATS_FILE_NAME, "r");

--- a/linux/network_info.c
+++ b/linux/network_info.c
@@ -34,7 +34,7 @@ void ReadReceiveBytes(const char *interface, uint64 *rx_bytes)
 	memset(file_name, 0, MAXPGPATH);
 
 	/* file name used to read the number of bytes received */
-	sprintf(file_name, "/sys/class/net/%s/statistics/rx_bytes", interface);
+	snprintf(file_name, MAXPGPATH, "/sys/class/net/%s/statistics/rx_bytes", interface);
 	ReadFileContent(file_name, rx_bytes);
 }
 
@@ -45,7 +45,7 @@ void ReadTransmitBytes(const char *interface, uint64 *tx_bytes)
 	memset(file_name, 0, MAXPGPATH);
 
 	/* file name used to read the number of bytes transmitted */
-	sprintf(file_name, "/sys/class/net/%s/statistics/tx_bytes", interface);
+	snprintf(file_name, MAXPGPATH, "/sys/class/net/%s/statistics/tx_bytes", interface);
 	ReadFileContent(file_name, tx_bytes);
 }
 
@@ -56,7 +56,7 @@ void ReadReceivePackets(const char *interface, uint64 *rx_packets)
 	memset(file_name, 0, MAXPGPATH);
 
 	/* file name used to read the number of packets received */
-	sprintf(file_name, "/sys/class/net/%s/statistics/rx_packets", interface);
+	snprintf(file_name, MAXPGPATH, "/sys/class/net/%s/statistics/rx_packets", interface);
 	ReadFileContent(file_name, rx_packets);
 }
 
@@ -67,7 +67,7 @@ void ReadTransmitPackets(const char *interface, uint64 *tx_packets)
 	memset(file_name, 0, MAXPGPATH);
 
 	/* file name used to read the number of packets transmitted */
-	sprintf(file_name, "/sys/class/net/%s/statistics/tx_packets", interface);
+	snprintf(file_name, MAXPGPATH, "/sys/class/net/%s/statistics/tx_packets", interface);
 	ReadFileContent(file_name, tx_packets);
 }
 
@@ -78,7 +78,7 @@ void ReadReceiveErrors(const char *interface, uint64 *rx_errors)
 	memset(file_name, 0, MAXPGPATH);
 
 	/* file name used to read the number of errors during receiver */
-	sprintf(file_name, "/sys/class/net/%s/statistics/rx_errors", interface);
+	snprintf(file_name, MAXPGPATH, "/sys/class/net/%s/statistics/rx_errors", interface);
 	ReadFileContent(file_name, rx_errors);
 }
 
@@ -89,7 +89,7 @@ void ReadTransmitErrors(const char *interface, uint64 *tx_errors)
 	memset(file_name, 0, MAXPGPATH);
 
 	/* file name used to read the number of errors during transmission */
-	sprintf(file_name, "/sys/class/net/%s/statistics/tx_errors", interface);
+	snprintf(file_name, MAXPGPATH, "/sys/class/net/%s/statistics/tx_errors", interface);
 	ReadFileContent(file_name, tx_errors);
 }
 
@@ -100,7 +100,7 @@ void ReadReceiveDropped(const char *interface, uint64 *rx_dropped)
 	memset(file_name, 0, MAXPGPATH);
 
 	/* file name used to read the number of packets dropped during receiver */
-	sprintf(file_name, "/sys/class/net/%s/statistics/rx_dropped", interface);
+	snprintf(file_name, MAXPGPATH, "/sys/class/net/%s/statistics/rx_dropped", interface);
 	ReadFileContent(file_name, rx_dropped);
 }
 
@@ -111,7 +111,7 @@ void ReadTransmitDropped(const char *interface, uint64 *tx_dropped)
 	memset(file_name, 0, MAXPGPATH);
 
 	/* file name used to read the number of packets dropped during transmission */
-	sprintf(file_name, "/sys/class/net/%s/statistics/tx_dropped", interface);
+	snprintf(file_name, MAXPGPATH, "/sys/class/net/%s/statistics/tx_dropped", interface);
 	ReadFileContent(file_name, tx_dropped);
 }
 
@@ -122,7 +122,7 @@ void ReadSpeedMbps(const char *interface, uint64 *speed)
 	memset(file_name, 0, MAXPGPATH);
 
 	/* file name used to read the speed of interface in Mbps */
-	sprintf(file_name, "/sys/class/net/%s/speed", interface);
+	snprintf(file_name, MAXPGPATH, "/sys/class/net/%s/speed", interface);
 	ReadFileContent(file_name, speed);
 }
 

--- a/linux/os_info.c
+++ b/linux/os_info.c
@@ -96,7 +96,7 @@ void ReadOSInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	}
 	else
 	{
-		sprintf(version, "%s %s", uts.sysname, uts.release);
+		snprintf(version, MAXPGPATH, "%s %s", uts.sysname, uts.release);
 		memcpy(architecture, uts.machine, strlen(uts.machine));
 	}
 

--- a/linux/system_stats_utils.c
+++ b/linux/system_stats_utils.c
@@ -170,7 +170,7 @@ bool read_process_status(int *active_processes, int *running_processes,
 
 		active_pro++;
 
-		sprintf(file_name,"/proc/%s/stat", ent->d_name);
+		snprintf(file_name, MIN_BUFFER_SIZE, "/proc/%s/stat", ent->d_name);
 
 		fpstat = fopen(file_name, "r");
 		if (fpstat == NULL)

--- a/windows/cpu_info.c
+++ b/windows/cpu_info.c
@@ -135,7 +135,7 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				int val = query_result.intVal;
 				char arch[MAXPGPATH];
 				memset(arch, 0x00, MAXPGPATH);
-				sprintf(arch, "%d", val);
+				snprintf(arch, MAXPGPATH, "%d", val);
 				values[Anum_architecture] = CStringGetTextDatum(arch);
 				VariantClear(&query_result);
 			}

--- a/windows/io_analysis.c
+++ b/windows/io_analysis.c
@@ -38,7 +38,7 @@ void ReadIOAnalysisInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 
 	for (deviceId = 0; deviceId <= MAX_DRIVE_COUNT; ++deviceId)
 	{
-		sprintf_s(szDevice, MAX_DEVICE_PATH, "\\\\.\\PhysicalDrive%d", deviceId);
+		snprintf(szDevice, MAX_DEVICE_PATH, "\\\\.\\PhysicalDrive%d", deviceId);
 
 		hDevice = CreateFile(szDevice, 0, FILE_SHARE_READ | FILE_SHARE_WRITE,
 			NULL, OPEN_EXISTING, 0, NULL);
@@ -87,7 +87,7 @@ void ReadIOAnalysisInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 			return;
 		}
 
-		sprintf_s(szDeviceDisplay, MAX_DEVICE_PATH, "PhysicalDrive%i", deviceId);
+		snprintf(szDeviceDisplay, MAX_DEVICE_PATH, "PhysicalDrive%i", deviceId);
 
 		values[Anum_device_name] = CStringGetTextDatum(szDeviceDisplay);
 		values[Anum_total_read] = UInt64GetDatum((uint64)diskPerformance.ReadCount);

--- a/windows/system_stats_utils.c
+++ b/windows/system_stats_utils.c
@@ -32,7 +32,7 @@ int is_process_running(int pid)
 	wchar_t  w_query[512];
 	size_t outSize;
 	char pid_str[20] = { 0 };
-	sinprintf(pid_str, sizeof(pid_str), "%d", pid);
+	snprintf(pid_str, sizeof(pid_str), "%d", pid);
 	snprintf(ptr, sizeof(ptr), "SELECT ThreadState, ThreadWaitReason FROM Win32_Thread WHERE ProcessHandle = %s", pid_str);
 	mbstowcs_s(&outSize, w_query, sizeof(ptr), ptr, sizeof(ptr));
 

--- a/windows/system_stats_utils.c
+++ b/windows/system_stats_utils.c
@@ -32,8 +32,8 @@ int is_process_running(int pid)
 	wchar_t  w_query[512];
 	size_t outSize;
 	char pid_str[20] = { 0 };
-	sprintf(pid_str, "%d", pid);
-	sprintf(ptr, "SELECT ThreadState, ThreadWaitReason FROM Win32_Thread WHERE ProcessHandle = %s", pid_str);
+	sinprintf(pid_str, sizeof(pid_str), "%d", pid);
+	snprintf(ptr, sizeof(ptr), "SELECT ThreadState, ThreadWaitReason FROM Win32_Thread WHERE ProcessHandle = %s", pid_str);
 	mbstowcs_s(&outSize, w_query, sizeof(ptr), ptr, sizeof(ptr));
 
 	IEnumWbemClassObject *results = NULL;


### PR DESCRIPTION
Replace the `sprintf` with `snprintf` to avoid buffer overflow. Writing too much data to the allocated space can lead to issues such as memory corruption or security threats. Some of the code scanner tool also gives warning for the usage of `sprintf`.

`snprintf` helps to prevent buffer overflows by ensuring data does not exceed a specified limit.

Reported by: @BillSmith-EDB 