### PR TITLE
Ensure the OS name is unquoted and doesn't include leading/trailing whitespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ endif
 ifeq ($(UNAME), Linux)
 OBJS = \
         system_stats.o \
+        misc.o \
         linux/system_stats_utils.o \
         linux/disk_info.o \
         linux/io_analysis.o \

--- a/linux/os_info.c
+++ b/linux/os_info.c
@@ -9,6 +9,7 @@
 
 #include "postgres.h"
 #include "system_stats.h"
+#include "misc.h"
 
 #include <unistd.h>
 #include <sys/utsname.h>
@@ -142,7 +143,7 @@ void ReadOSInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		{
 			int len = strlen(line_buf);
 			if (strstr(line_buf, OS_DESC_SEARCH_TEXT) != NULL)
-				memcpy(os_name, (line_buf + strlen(OS_DESC_SEARCH_TEXT)), (len - strlen(OS_DESC_SEARCH_TEXT)));
+				memcpy(os_name, remove_quotes(str_trim(line_buf + strlen(OS_DESC_SEARCH_TEXT))), (len - strlen(OS_DESC_SEARCH_TEXT)));
 
 			/* Free the allocated line buffer */
 			if (line_buf != NULL)

--- a/misc.c
+++ b/misc.c
@@ -1,0 +1,46 @@
+/*------------------------------------------------------------------------
+ * misc.c
+ *              Miscellaneous utilities
+ *
+ * Copyright (c) 2020, EnterpriseDB Corporation. All Rights Reserved.
+ *
+ *------------------------------------------------------------------------
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "misc.h"
+
+
+char *str_ltrim(char *s)
+{
+    while(isspace(*s)) s++;
+    return s;
+}
+
+
+char *str_rtrim(char *s)
+{
+    char *back = s + strlen(s);
+    while(isspace(*--back));
+    *(back+1) = '\0';
+    return s;
+}
+
+
+char *str_trim(char *s)
+{
+    return str_rtrim(str_ltrim(s));
+}
+
+
+char *remove_quotes(char *s)
+{
+    if (s[0] == '"' && s[strlen(s) - 1] == '"')
+    {
+        s[strlen(s) - 1] = '\0';
+        return s + 1;
+    }
+    return s;
+}

--- a/misc.h
+++ b/misc.h
@@ -1,0 +1,18 @@
+/*------------------------------------------------------------------------
+ * misc.h
+ *              Misc functions
+ *
+ * Copyright (c) 2020, EnterpriseDB Corporation. All Rights Reserved.
+ *
+ *------------------------------------------------------------------------
+ */
+#ifndef MISC_H
+#define MISC_H
+
+char *str_ltrim(char *s);
+char *str_rtrim(char *s);
+char *str_trim(char *s);
+
+char *remove_quotes(char *s);
+
+#endif // MISC_H


### PR DESCRIPTION
Values in /etc/os-release can be quoted on some platforms. 
Additionally, the code was including the \n at the end of the line.