### PR TITLE
Makefile: remove inexistent test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ DATA = system_stats--1.0--2.0.sql  system_stats--1.0.sql  system_stats--2.0.sql 
 PGFILEDESC = "system_stats - system statistics functions"
 
 
-REGRESS = system_stats
 
 ifndef USE_PGXS
 top_builddir = ../..


### PR DESCRIPTION
Currently there is no test file in system_stats, but the Makefile expects one to exist. Until a test is devised, we should have make not error with a message of inexistent file. In the future, we should also add some useful testing to system_stats.
