### PR TITLE
use PG_MODULE_MAGIC_EXT on v18+

### DIFF
--- a/system_stats.c
+++ b/system_stats.c
@@ -25,7 +25,11 @@
 #include "storage/fd.h"
 #include "utils/timestamp.h"
 
+#ifdef PG_MODULE_MAGIC_EXT
+PG_MODULE_MAGIC_EXT(.name = "system_stats", .version = "3.2.0");
+#else
 PG_MODULE_MAGIC;
+#endif
 
 /* called when extension is loaded */
 void _PG_init(void);


### PR DESCRIPTION
By reporting the full version through PG_MODULE_MAGIC_EXT, the shared object can identify itself to the outer world with more precision than only the extension version. For instance, if there is any change that fixes bugs or enhances features without changing the sql interface, the extension should not be bumped on the sql level, remaining on 3.2, while git tags and shared object will advance from 3.2.0 to 3.2.1 to 3.2.2, providing details on bugfixes through semantic versioning.