### PR TITLE
Extracts domain name from FQDN, if fails then tries to read it from /…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ OBJS = \
         linux/network_info.o \
         linux/cpu_memory_by_process.o
 
-HEADERS = system_stats.h
+HEADERS = system_stats.h misc.h
 
 endif
 

--- a/misc.c
+++ b/misc.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "misc.h"
 


### PR DESCRIPTION
This PR fixes domain name issue as follows
   1. Try DNS resolution to get FQDN, then extract domain
   2. Read from /etc/resolv.conf (domain or search directive)
   3. Fallback to getdomainname() with validation