### PR TITLE
Include ctype.h for character handling functions

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "misc.h"
 


### PR DESCRIPTION
Adding the `<ctype.h>` header resolves the implicit declaration error for the `isspace` function, enabling compilation on the Postgres18 Docker Official Image.

Fixes #54