### PR TITLE
fix possible buffer overflows

### DIFF
--- a/linux/cpu_memory_by_process.c
+++ b/linux/cpu_memory_by_process.c
@@ -126,16 +126,16 @@ uint64 ReadTotalCPUUsage()
 	char       *line_buf = NULL;
 	size_t     line_buf_size = 0;
 	ssize_t    line_size;
-	char       cpu_name[MAXPGPATH];
+	char       cpu_name[MAXPGPATH + 1];
 	uint64     total_cpu_time = 0;
 	uint64     usermode_normal_process = 0;
 	uint64     usermode_niced_process = 0;
 	uint64     kernelmode_process = 0;
 	uint64     idle_mode = 0;
 	uint64     io_completion = 0;
-	const char *scan_fmt = "%s %llu %llu %llu %llu %llu";
+	const char *scan_fmt = "%" CppAsString2(MAXPGPATH) "s %llu %llu %llu %llu %llu";
 
-	memset(cpu_name, 0, MAXPGPATH);
+	memset(cpu_name, 0, MAXPGPATH + 1);
 
 	cpu_stats_file = fopen(CPU_USAGE_STATS_FILENAME, "r");
 
@@ -200,7 +200,7 @@ void ReadCPUMemoryUsage(int sample)
 	struct dirent *ent;
 	char  file_name[MAXPGPATH];
 	long utime_ticks, stime_ticks;
-	char process_name[MAXPGPATH] = {0};
+	char process_name[MAXPGPATH + 1] = {0};
 	int pid = 0;
 	long unsigned int mem_rss = 0;
 	unsigned  long long  process_up_since = 0;
@@ -243,7 +243,7 @@ void ReadCPUMemoryUsage(int sample)
 		if (fpstat == NULL)
 			continue;
 
-		if (fscanf(fpstat, "%d %s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %lu"
+		if (fscanf(fpstat, "%d %" CppAsString2(MAXPGPATH) "s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %lu"
 					"%lu %*d %*d %*d %*d %*d %*d %llu %*u %ld",
 					&pid, process_name, &utime_ticks, &stime_ticks, &process_up_since, &mem_rss) == EOF)
 		{
@@ -263,7 +263,7 @@ void ReadCPUMemoryUsage(int sample)
 			}
 
 			iter->pid = pid;
-			memcpy(iter->name, process_name, MAXPGPATH);
+			strncpy(iter->name, process_name, MAXPGPATH);
 			iter->process_cpu_sample_1 = utime_ticks + stime_ticks;
 			iter->rss_memory = mem_rss;
 			process_up_since = (unsigned long long)((unsigned long long)sys_uptime - (process_up_since/HZ));

--- a/linux/io_analysis.c
+++ b/linux/io_analysis.c
@@ -21,7 +21,7 @@ void ReadIOAnalysisInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	char       *line_buf = NULL;
 	size_t     line_buf_size = 0;
 	ssize_t    line_size;
-	char       device_name[MAXPGPATH];
+	char       device_name[MAXPGPATH + 1];
 	char       file_name[MAXPGPATH];
 	uint64     read_completed = 0;
 	uint64     sector_read = 0;
@@ -30,10 +30,10 @@ void ReadIOAnalysisInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	uint64     sector_written = 0;
 	uint64     time_spent_writing_ms = 0;
 	uint64     sector_size = 512;
-	const char *scan_fmt = "%*d %*d %s %lld %*lld %lld %lld %lld %*lld %lld %lld";
+	const char *scan_fmt = "%*d %*d %" CppAsString2(MAXPGPATH) "s %lld %*lld %lld %lld %lld %*lld %lld %lld";
 
 	memset(nulls, 0, sizeof(nulls));
-	memset(device_name, 0, MAXPGPATH);
+	memset(device_name, 0, MAXPGPATH + 1);
 	memset(file_name, 0, MAXPGPATH);
 
 	/* file name used to read the sector size in bytes */


### PR DESCRIPTION
When reading a string from scanf functions, it is important to always provide a maximum width for the field.

The idiomatic way in postgres is to allocate one size larger than MAXPGPATH and to use it in the format.

Extra care should be taken to zero the full size, as well as to copy to other regions that may be smaller.

This was identified by SonarQube.