### PR TITLE
mark local variables as static

### DIFF
--- a/darwin/cpu_memory_by_process.c
+++ b/darwin/cpu_memory_by_process.c
@@ -43,9 +43,9 @@ typedef struct node
 	struct node * next;
 } node_t;
 
-node_t *head = NULL;
-node_t *prev = NULL;
-node_t *iter = NULL;
+static node_t *head = NULL;
+static node_t *prev = NULL;
+static node_t *iter = NULL;
 
 /* Function used to create the data structure for each process CPU and memory usage information */
 void CreateCPUMemoryList(int sample)

--- a/linux/cpu_memory_by_process.c
+++ b/linux/cpu_memory_by_process.c
@@ -35,9 +35,9 @@ typedef struct node
 	struct node * next;
 } node_t;
 
-node_t *head = NULL;
-node_t *prev = NULL;
-node_t *iter = NULL;
+static node_t *head = NULL;
+static node_t *prev = NULL;
+static node_t *iter = NULL;
 
 /* Function used to get number of processor count */
 int ReadTotalProcessors(void);


### PR DESCRIPTION
When a variable is not used across units and isn't exported, marking it as static avoids warnings like:

linux/cpu_memory_by_process.c:38:9: warning: no previous declaration for ‘head’ [-Wmissing-variable-declarations]
   38 | node_t *head = NULL;
      |         ^~~~
linux/cpu_memory_by_process.c:39:9: warning: no previous declaration for ‘prev’ [-Wmissing-variable-declarations]
   39 | node_t *prev = NULL;
      |         ^~~~
linux/cpu_memory_by_process.c:40:9: warning: no previous declaration for ‘iter’ [-Wmissing-variable-declarations]
   40 | node_t *iter = NULL;
      |         ^~~~