### PR TITLE
chore: bump system_stats version to 3.2.1

### DIFF
--- a/system_stats.c
+++ b/system_stats.c
@@ -26,7 +26,7 @@
 #include "utils/timestamp.h"
 
 #ifdef PG_MODULE_MAGIC_EXT
-PG_MODULE_MAGIC_EXT(.name = "system_stats", .version = "3.2.0");
+PG_MODULE_MAGIC_EXT(.name = "system_stats", .version = "3.2.1");
 #else
 PG_MODULE_MAGIC;
 #endif


### PR DESCRIPTION
For the new v3.2.1 release, bump the version of the extension.