### PR TITLE
feat(DB-3080): Add virtual_memory, swap, IO metrics to pg_sys_cpu_memory_by_process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ DATA = system_stats--1.0--2.0.sql  system_stats--1.0.sql  system_stats--2.0.sql 
 PGFILEDESC = "system_stats - system statistics functions"
 
 # Regression tests
-REGRESS = smoke_test system_stats
+REGRESS = smoke_test system_stats upgrade_test
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ PG_LDFLAGS= -framework IOKit -framework CoreFoundation
 endif
 
 EXTENSION = system_stats
-DATA = system_stats--1.0--2.0.sql  system_stats--1.0.sql  system_stats--2.0.sql  system_stats--2.0--3.0.sql  system_stats--3.0.sql  uninstall_system_stats.sql
+DATA = system_stats--1.0--2.0.sql  system_stats--1.0.sql  system_stats--2.0.sql  system_stats--2.0--3.0.sql  system_stats--3.0.sql  system_stats--3.0--4.0.sql  system_stats--4.0.sql  uninstall_system_stats.sql
 PGFILEDESC = "system_stats - system statistics functions"
 
 # Regression tests

--- a/README.md
+++ b/README.md
@@ -218,14 +218,14 @@ NOTE: macOS does not allow access to to process information for other users.
 ### pg_sys_cpu_memory_by_process
 - PID of the process (pid)
 - Process name (name)
-- Running time in seconds (running_since_seconds)
+- Running time in seconds (running_since_seconds) - NULL on macOS
 - CPU usage in percent time spent on CPU (cpu_usage)
 - Memory usage as percentage (memory_usage)
 - Total memory used in bytes (memory_bytes)
 - Virtual memory (VSZ) in bytes (virtual_memory_bytes)
-- Swap usage in bytes (swap_usage_bytes) - NULL on macOS
-- Total bytes read from disk (io_read_bytes)
-- Total bytes written to disk (io_write_bytes)
+- Swap usage in bytes (swap_usage_bytes) - NULL on macOS; on Windows, reports page-file-backed committed memory
+- Bytes read from disk (io_read_bytes) - cumulative on Linux/macOS; per-second rate on Windows
+- Bytes written to disk (io_write_bytes) - cumulative on Linux/macOS; per-second rate on Windows
 
 ## Test Suites
 

--- a/README.md
+++ b/README.md
@@ -216,11 +216,16 @@ NOTE: macOS does not allow access to to process information for other users.
 - Interface speed in mbps
 
 ### pg_sys_cpu_memory_by_process
-- PID of the process
-- Process name
-- CPU usage in percent time spent on CPU
-- Memory usage in bytes
-- Total memory used in bytes
+- PID of the process (pid)
+- Process name (name)
+- Running time in seconds (running_since_seconds)
+- CPU usage in percent time spent on CPU (cpu_usage)
+- Memory usage as percentage (memory_usage)
+- Total memory used in bytes (memory_bytes)
+- Virtual memory (VSZ) in bytes (virtual_memory_bytes)
+- Swap usage in bytes (swap_usage_bytes) - NULL on macOS
+- Total bytes read from disk (io_read_bytes)
+- Total bytes written to disk (io_write_bytes)
 
 ## Test Suites
 

--- a/darwin/cpu_memory_by_process.c
+++ b/darwin/cpu_memory_by_process.c
@@ -19,6 +19,7 @@
 
 #include <libproc.h>
 #include <sys/proc_info.h>
+#include <sys/resource.h>
 
 extern int get_process_list(struct kinfo_proc **proc_list, size_t *proc_count);
 extern uint64 find_cpu_times(void);
@@ -38,6 +39,10 @@ typedef struct node
 	long long unsigned int process_cpu_sample_1;
 	long long unsigned int process_cpu_sample_2;
 	long long unsigned int rss_memory;
+	long long unsigned int virtual_memory;
+	long long unsigned int io_read_bytes;
+	long long unsigned int io_write_bytes;
+	bool                   has_io;
 	char name[MAXPGPATH];
 	int  process_owned_by_user;
 	struct node * next;
@@ -89,7 +94,23 @@ void CreateCPUMemoryList(int sample)
 			{
 				iter->process_cpu_sample_1 = pti.pti_total_user + pti.pti_total_system;
 				iter->rss_memory = pti.pti_resident_size;
+				iter->virtual_memory = pti.pti_virtual_size;
 				iter->process_owned_by_user = 1;
+			}
+
+			{
+				struct rusage_info_v2 rusage;
+				if (proc_pid_rusage(
+						(pid_t)iter->pid,
+						RUSAGE_INFO_V2,
+						(rusage_info_t *)&rusage) == 0)
+				{
+					iter->io_read_bytes = rusage.ri_diskio_bytesread;
+					iter->io_write_bytes = rusage.ri_diskio_byteswritten;
+					iter->has_io = 1;
+				}
+				else
+					iter->has_io = 0;
 			}
 
 			iter->next = NULL;
@@ -184,18 +205,38 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 			values[Anum_percent_cpu_usage] = Float4GetDatum(cpu_usage);
 			values[Anum_percent_memory_usage] = Float4GetDatum(memory_usage);
 			values[Anum_process_memory_bytes] = UInt64GetDatum((uint64)rss_memory);
+			values[Anum_process_virtual_memory_bytes] =
+				UInt64GetDatum((uint64)current->virtual_memory);
 		}
 		else
 		{
 			nulls[Anum_percent_cpu_usage] = true;
 			nulls[Anum_percent_memory_usage] = true;
 			nulls[Anum_process_memory_bytes] = true;
+			nulls[Anum_process_virtual_memory_bytes] = true;
 		}
 
 		values[Anum_process_pid] = Int32GetDatum(process_pid);
 		values[Anum_process_name] = CStringGetTextDatum(command);
 
 		nulls[Anum_process_running_since] = true;
+
+		/* swap is not available per-process on macOS */
+		nulls[Anum_process_swap_usage_bytes] = true;
+
+		/* IO read/write */
+		if (current->has_io)
+		{
+			values[Anum_process_io_read_bytes] =
+				UInt64GetDatum((uint64)current->io_read_bytes);
+			values[Anum_process_io_write_bytes] =
+				UInt64GetDatum((uint64)current->io_write_bytes);
+		}
+		else
+		{
+			nulls[Anum_process_io_read_bytes] = true;
+			nulls[Anum_process_io_write_bytes] = true;
+		}
 
 		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 
@@ -204,6 +245,16 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		process_pid = 0;
 		cpu_usage = 0.0;
 		memory_usage = 0.0;
+
+		/* Reset all null flags for next iteration */
+		nulls[Anum_percent_cpu_usage] = false;
+		nulls[Anum_percent_memory_usage] = false;
+		nulls[Anum_process_memory_bytes] = false;
+		nulls[Anum_process_running_since] = false;
+		nulls[Anum_process_virtual_memory_bytes] = false;
+		nulls[Anum_process_swap_usage_bytes] = false;
+		nulls[Anum_process_io_read_bytes] = false;
+		nulls[Anum_process_io_write_bytes] = false;
 
 		del_iter = current;
 		current = current->next;

--- a/darwin/cpu_memory_by_process.c
+++ b/darwin/cpu_memory_by_process.c
@@ -178,6 +178,7 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	/* Read the first sample for cpu and memory usage by each process */
 	CreateCPUMemoryList(READ_PROCESS_CPU_USAGE_FIRST_SAMPLE);
 	pg_usleep(100000);
+	CHECK_FOR_INTERRUPTS();
 	/* Read the second sample for cpu and memory usage by each process */
 	total_cpu_usage_2 = find_cpu_times();
 	CreateCPUMemoryList(READ_PROCESS_CPU_USAGE_SECOND_SAMPLE);

--- a/darwin/cpu_memory_by_process.c
+++ b/darwin/cpu_memory_by_process.c
@@ -70,7 +70,7 @@ void CreateCPUMemoryList(int sample)
 		pid_t pid;
 		struct proc_taskinfo pti;
 		int ret_val = 0;
- 
+
 		pid = (pid_t)proclist->kp_proc.p_pid;
 		ret_val = proc_pidinfo(proclist->kp_proc.p_pid, PROC_PIDTASKINFO, 0, &pti, sizeof(pti));
 		if ((ret_val <= 0) || ((unsigned long)ret_val < sizeof(pti)))
@@ -87,7 +87,8 @@ void CreateCPUMemoryList(int sample)
 
 			memset(iter, 0x00, sizeof(node_t));
 			iter->pid = proclist->kp_proc.p_pid;
-			memcpy(iter->name, proclist->kp_proc.p_comm, MAXPGPATH);
+			/* p_comm is only MAXCOMLEN+1 (17) bytes; strlcpy avoids over-read */
+			strlcpy(iter->name, proclist->kp_proc.p_comm, MAXPGPATH);
 			if ((ret_val <= 0) || ((unsigned long)ret_val < sizeof(pti)))
 				iter->process_owned_by_user = 0;
 			else
@@ -100,8 +101,7 @@ void CreateCPUMemoryList(int sample)
 
 			{
 				struct rusage_info_v2 rusage;
-				if (proc_pid_rusage(
-						(pid_t)iter->pid,
+				if (proc_pid_rusage((pid_t)iter->pid,
 						RUSAGE_INFO_V2,
 						(rusage_info_t *)&rusage) == 0)
 				{
@@ -127,7 +127,8 @@ void CreateCPUMemoryList(int sample)
 			{
 				if (current->pid == (int)pid)
 				{
-					if (!(ret_val <= 0) || ((unsigned long)ret_val < sizeof(pti)))
+					/* Check that proc_pidinfo succeeded */
+					if ((ret_val > 0) && ((unsigned long)ret_val >= sizeof(pti)))
 						current->process_cpu_sample_2 = pti.pti_total_user + pti.pti_total_system;
 					break;
 				}
@@ -151,11 +152,10 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	float4     cpu_usage = 0.0;
 	float4     memory_usage = 0.0;
 	int        desc[2];
-	uint64     total_memory;
-	uint64     page_size_bytes;
+	uint64     total_memory = 0;
 	int        num_cpus = 0;
 	size_t     size_cpus = sizeof(num_cpus);
-	size_t     p_size = sizeof(page_size_bytes);
+	size_t     p_size = sizeof(total_memory);
 	long long unsigned int     rss_memory;
 	node_t     *del_iter = NULL;
 	node_t     *current  = NULL;
@@ -174,14 +174,10 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	if (sysctlbyname("hw.ncpu", &num_cpus, &size_cpus, 0, 0) == -1)
 		ereport(DEBUG1, (errmsg("Error while getting total CPU cores")));
 
-	/* Get the page size */
-	if (sysctlbyname("hw.pagesize", &page_size_bytes, &p_size, 0, 0) == -1)
-		ereport(DEBUG1, (errmsg("Error while getting page size information")));
-
 	total_cpu_usage_1 = find_cpu_times();
 	/* Read the first sample for cpu and memory usage by each process */
 	CreateCPUMemoryList(READ_PROCESS_CPU_USAGE_FIRST_SAMPLE);
-	usleep(100000);
+	pg_usleep(100000);
 	/* Read the second sample for cpu and memory usage by each process */
 	total_cpu_usage_2 = find_cpu_times();
 	CreateCPUMemoryList(READ_PROCESS_CPU_USAGE_SECOND_SAMPLE);
@@ -192,15 +188,40 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	// Process the CPU and memory information from linked list and free it once processed */
 	while (current != NULL)
 	{
+		/* Reset all null flags for this iteration */
+		memset(nulls, 0, sizeof(nulls));
+
 		process_pid = current->pid;
 		memcpy(command, current->name, MAXPGPATH);
 		if (current->process_owned_by_user)
 		{
-			float diff_sample = (float)(current->process_cpu_sample_2 - current->process_cpu_sample_1) / 1000000000.0;
-			cpu_usage = (num_cpus) * (diff_sample) * 100 / (float) ((total_cpu_usage_2 - total_cpu_usage_1)/CLK_TCK);
+			/*
+			 * Cast to float before dividing by CLK_TCK to avoid integer
+			 * truncation (the tick delta can be smaller than CLK_TCK for
+			 * short sample windows, which would truncate to zero).
+			 */
+			float diff_total =
+				(float)(total_cpu_usage_2 - total_cpu_usage_1) /
+				(float)CLK_TCK;
+			/* Guard against division by zero or unsigned underflow */
+			if (diff_total <= 0.0 || total_cpu_usage_2 < total_cpu_usage_1
+				|| current->process_cpu_sample_2 < current->process_cpu_sample_1)
+				cpu_usage = 0.0;
+			else
+			{
+				float diff_sample =
+					(float)(current->process_cpu_sample_2 -
+					current->process_cpu_sample_1) /
+					1000000000.0;
+				cpu_usage = (num_cpus) * (diff_sample) * 100 / diff_total;
+			}
 			cpu_usage = (float)((int)(cpu_usage * 100 + 0.5))/100;
 			rss_memory = current->rss_memory;
-			memory_usage = (rss_memory/(float)total_memory)*100;
+			/* Guard against division by zero when total memory is unavailable */
+			if (total_memory == 0)
+				memory_usage = 0.0;
+			else
+				memory_usage = (rss_memory/(float)total_memory)*100;
 			memory_usage = (float)((int)(memory_usage * 100 + 0.5))/100;
 			values[Anum_percent_cpu_usage] = Float4GetDatum(cpu_usage);
 			values[Anum_percent_memory_usage] = Float4GetDatum(memory_usage);
@@ -215,11 +236,6 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 			nulls[Anum_process_memory_bytes] = true;
 			nulls[Anum_process_virtual_memory_bytes] = true;
 		}
-
-		values[Anum_process_pid] = Int32GetDatum(process_pid);
-		values[Anum_process_name] = CStringGetTextDatum(command);
-
-		nulls[Anum_process_running_since] = true;
 
 		/* swap is not available per-process on macOS */
 		nulls[Anum_process_swap_usage_bytes] = true;
@@ -238,6 +254,11 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 			nulls[Anum_process_io_write_bytes] = true;
 		}
 
+		values[Anum_process_pid] = Int32GetDatum(process_pid);
+		values[Anum_process_name] = CStringGetTextDatum(command);
+
+		nulls[Anum_process_running_since] = true;
+
 		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 
 		//reset the value again
@@ -245,16 +266,6 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		process_pid = 0;
 		cpu_usage = 0.0;
 		memory_usage = 0.0;
-
-		/* Reset all null flags for next iteration */
-		nulls[Anum_percent_cpu_usage] = false;
-		nulls[Anum_percent_memory_usage] = false;
-		nulls[Anum_process_memory_bytes] = false;
-		nulls[Anum_process_running_since] = false;
-		nulls[Anum_process_virtual_memory_bytes] = false;
-		nulls[Anum_process_swap_usage_bytes] = false;
-		nulls[Anum_process_io_read_bytes] = false;
-		nulls[Anum_process_io_write_bytes] = false;
 
 		del_iter = current;
 		current = current->next;

--- a/expected/system_stats.out
+++ b/expected/system_stats.out
@@ -306,12 +306,21 @@ LIMIT 1;
 SELECT
     count(*) FILTER (WHERE virtual_memory_bytes > 0) > 0 AS has_virtual_memory,
     count(*) FILTER (WHERE virtual_memory_bytes < 0) = 0 AS no_negative_virtual_memory,
+    count(*) FILTER (WHERE swap_usage_bytes < 0) = 0 AS no_negative_swap,
     count(*) FILTER (WHERE io_read_bytes < 0) = 0 AS no_negative_io_read,
     count(*) FILTER (WHERE io_write_bytes < 0) = 0 AS no_negative_io_write
 FROM pg_sys_cpu_memory_by_process();
- has_virtual_memory | no_negative_virtual_memory | no_negative_io_read | no_negative_io_write 
---------------------+----------------------------+---------------------+----------------------
- t                  | t                          | t                   | t
+ has_virtual_memory | no_negative_virtual_memory | no_negative_swap | no_negative_io_read | no_negative_io_write 
+--------------------+----------------------------+------------------+---------------------+----------------------
+ t                  | t                          | t                | t                   | t
+(1 row)
+
+-- Verify function returns exactly 10 output columns
+SELECT array_length(proargnames, 1) = 10 AS correct_column_count
+FROM pg_proc WHERE proname = 'pg_sys_cpu_memory_by_process';
+ correct_column_count 
+----------------------
+ t
 (1 row)
 
 -- ============================================================================

--- a/expected/system_stats.out
+++ b/expected/system_stats.out
@@ -36,7 +36,7 @@ SELECT
 FROM pg_sys_os_info();
  has_name | has_version | has_host_name | has_handle_count | has_process_count | has_thread_count | has_architecture 
 ----------+-------------+---------------+------------------+-------------------+------------------+------------------
- t        | t           | t             | t                | t                 | t                | t
+ t        | t           | t             |                  | t                 |                  | t
 (1 row)
 
 -- Test that name contains expected text (platform-agnostic check)
@@ -74,7 +74,7 @@ SELECT
 FROM pg_sys_cpu_info();
  has_model_name | processor_type_check | has_logical_processors | has_cores | cores_less_than_logical | has_architecture | has_clock_speed 
 ----------------+----------------------+------------------------+-----------+-------------------------+------------------+-----------------
- t              | t                    | f                      | t         | f                       | t                | t
+ t              | t                    | t                      | t         | t                       | t                | 
 (1 row)
 
 -- ============================================================================
@@ -181,7 +181,7 @@ SELECT
 FROM pg_sys_cpu_usage_info();
  usermode_valid | kernelmode_valid | idle_valid | io_valid 
 ----------------+------------------+------------+----------
- t              | t                | t          | t
+ t              | t                | t          | 
 (1 row)
 
 -- ============================================================================
@@ -285,7 +285,37 @@ FROM pg_sys_cpu_memory_by_process();
 (1 row)
 
 -- ============================================================================
--- Test 11: Multiple calls (test caching and performance)
+-- Test 11: pg_sys_cpu_memory_by_process new columns
+-- ============================================================================
+\echo '### Testing pg_sys_cpu_memory_by_process new columns ###'
+### Testing pg_sys_cpu_memory_by_process new columns ###
+-- Verify new columns exist and have correct types
+SELECT
+    pg_typeof(virtual_memory_bytes) = 'bigint'::regtype AS virtual_memory_type_ok,
+    pg_typeof(swap_usage_bytes) = 'bigint'::regtype AS swap_type_ok,
+    pg_typeof(io_read_bytes) = 'bigint'::regtype AS io_read_type_ok,
+    pg_typeof(io_write_bytes) = 'bigint'::regtype AS io_write_type_ok
+FROM pg_sys_cpu_memory_by_process()
+LIMIT 1;
+ virtual_memory_type_ok | swap_type_ok | io_read_type_ok | io_write_type_ok 
+------------------------+--------------+-----------------+------------------
+ t                      | t            | t               | t
+(1 row)
+
+-- Verify at least one process has virtual memory > 0 and no negative values exist
+SELECT
+    count(*) FILTER (WHERE virtual_memory_bytes > 0) > 0 AS has_virtual_memory,
+    count(*) FILTER (WHERE virtual_memory_bytes < 0) = 0 AS no_negative_virtual_memory,
+    count(*) FILTER (WHERE io_read_bytes < 0) = 0 AS no_negative_io_read,
+    count(*) FILTER (WHERE io_write_bytes < 0) = 0 AS no_negative_io_write
+FROM pg_sys_cpu_memory_by_process();
+ has_virtual_memory | no_negative_virtual_memory | no_negative_io_read | no_negative_io_write 
+--------------------+----------------------------+---------------------+----------------------
+ t                  | t                          | t                   | t
+(1 row)
+
+-- ============================================================================
+-- Test 12: Multiple calls (test caching and performance)
 -- ============================================================================
 \echo '### Testing multiple calls (caching) ###'
 ### Testing multiple calls (caching) ###
@@ -320,7 +350,7 @@ SELECT
 (1 row)
 
 -- ============================================================================
--- Test 12: Data type verification
+-- Test 13: Data type verification
 -- ============================================================================
 \echo '### Testing data types ###'
 ### Testing data types ###
@@ -347,7 +377,7 @@ FROM pg_sys_cpu_info();
 (1 row)
 
 -- ============================================================================
--- Test 13: NULL handling
+-- Test 14: NULL handling
 -- ============================================================================
 \echo '### Testing NULL handling ###'
 ### Testing NULL handling ###

--- a/expected/upgrade_test.out
+++ b/expected/upgrade_test.out
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- Upgrade path test: system_stats 3.0 -> 4.0
+-- ============================================================================
+\echo '### Testing upgrade path 3.0 -> 4.0 ###'
+### Testing upgrade path 3.0 -> 4.0 ###
+-- Clean slate
+DROP EXTENSION IF EXISTS system_stats CASCADE;
+-- Install version 3.0
+CREATE EXTENSION system_stats VERSION '3.0';
+-- Verify old function has 6 output columns
+SELECT array_length(proargnames, 1) = 6 AS v3_has_6_columns
+FROM pg_proc WHERE proname = 'pg_sys_cpu_memory_by_process';
+ v3_has_6_columns 
+------------------
+ t
+(1 row)
+
+-- Verify current version
+SELECT extversion = '3.0' AS is_version_3
+FROM pg_extension WHERE extname = 'system_stats';
+ is_version_3 
+--------------
+ t
+(1 row)
+
+-- Upgrade to 4.0
+ALTER EXTENSION system_stats UPDATE TO '4.0';
+-- Verify new version
+SELECT extversion = '4.0' AS is_version_4
+FROM pg_extension WHERE extname = 'system_stats';
+ is_version_4 
+--------------
+ t
+(1 row)
+
+-- Verify function now has 10 output columns
+SELECT array_length(proargnames, 1) = 10 AS v4_has_10_columns
+FROM pg_proc WHERE proname = 'pg_sys_cpu_memory_by_process';
+ v4_has_10_columns 
+-------------------
+ t
+(1 row)
+
+-- Verify new columns exist with correct types
+SELECT
+    pg_typeof(virtual_memory_bytes) = 'bigint'::regtype AS virtual_memory_type_ok,
+    pg_typeof(swap_usage_bytes) = 'bigint'::regtype AS swap_type_ok,
+    pg_typeof(io_read_bytes) = 'bigint'::regtype AS io_read_type_ok,
+    pg_typeof(io_write_bytes) = 'bigint'::regtype AS io_write_type_ok
+FROM pg_sys_cpu_memory_by_process()
+LIMIT 1;
+ virtual_memory_type_ok | swap_type_ok | io_read_type_ok | io_write_type_ok 
+------------------------+--------------+-----------------+------------------
+ t                      | t            | t               | t
+(1 row)
+
+-- Verify first 6 columns preserved (backward-compatible order)
+SELECT proargnames[1:6] = ARRAY['pid','name','running_since_seconds',
+    'cpu_usage','memory_usage','memory_bytes'] AS first_6_columns_match
+FROM pg_proc WHERE proname = 'pg_sys_cpu_memory_by_process';
+ first_6_columns_match 
+-----------------------
+ t
+(1 row)
+
+-- Clean up
+DROP EXTENSION system_stats;

--- a/linux/cpu_memory_by_process.c
+++ b/linux/cpu_memory_by_process.c
@@ -187,7 +187,7 @@ void ReadCPUMemoryUsage(int sample)
 	FILE *fpstat;
 	struct dirent *ent;
 	char  file_name[MAXPGPATH];
-	long utime_ticks, stime_ticks;
+	unsigned long utime_ticks, stime_ticks;
 	char process_name[MAXPGPATH + 1] = {0};
 	int pid = 0;
 	long unsigned int mem_rss = 0;
@@ -405,6 +405,8 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	ReadCPUMemoryUsage(READ_PROCESS_CPU_USAGE_SECOND_SAMPLE);
 
 	page_size_bytes = sysconf(_SC_PAGESIZE);
+	if (page_size_bytes <= 0)
+		page_size_bytes = 4096;  /* fallback to common default */
 
 	// Iterate through head and read all the informations */
 	current = head;

--- a/linux/cpu_memory_by_process.c
+++ b/linux/cpu_memory_by_process.c
@@ -30,6 +30,12 @@ typedef struct node
 	long long unsigned int process_cpu_sample_1;
 	long long unsigned int process_cpu_sample_2;
 	long long unsigned int rss_memory;
+	unsigned long long     vsize;
+	long long unsigned int swap_bytes;
+	long long unsigned int io_read_bytes;
+	long long unsigned int io_write_bytes;
+	bool                   has_swap;
+	bool                   has_io;
 	unsigned long long process_up_since_seconds;
 	char name[MAXPGPATH];
 	struct node * next;
@@ -47,6 +53,11 @@ uint64 ReadTotalPhysicalMemory(void);
 uint64 ReadTotalCPUUsage(void);
 /* Function used to read total memory usage for each process */
 void ReadCPUMemoryUsage(int sample);
+/* Forward declarations for process swap and IO reading */
+static bool ReadProcessSwap(int pid, long long unsigned int *swap_bytes);
+static bool ReadProcessIO(int pid,
+		long long unsigned int *read_bytes,
+		long long unsigned int *write_bytes);
 
 void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc);
 
@@ -204,6 +215,7 @@ void ReadCPUMemoryUsage(int sample)
 	int pid = 0;
 	long unsigned int mem_rss = 0;
 	unsigned  long long  process_up_since = 0;
+	unsigned long long vsize = 0;
 	int        HZ = 100;
 	long       tlk = -1;
 	struct     sysinfo s_info;
@@ -244,8 +256,8 @@ void ReadCPUMemoryUsage(int sample)
 			continue;
 
 		if (fscanf(fpstat, "%d %" CppAsString2(MAXPGPATH) "s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %lu"
-					"%lu %*d %*d %*d %*d %*d %*d %llu %*u %ld",
-					&pid, process_name, &utime_ticks, &stime_ticks, &process_up_since, &mem_rss) == EOF)
+					"%lu %*d %*d %*d %*d %*d %*d %llu %llu %ld",
+					&pid, process_name, &utime_ticks, &stime_ticks, &process_up_since, &vsize, &mem_rss) == EOF)
 		{
 			ereport(DEBUG1,
 				(errmsg("Error in parsing file '/proc/%d/stat'", pid)));
@@ -266,7 +278,11 @@ void ReadCPUMemoryUsage(int sample)
 			strncpy(iter->name, process_name, MAXPGPATH);
 			iter->process_cpu_sample_1 = utime_ticks + stime_ticks;
 			iter->rss_memory = mem_rss;
-			process_up_since = (unsigned long long)((unsigned long long)sys_uptime - (process_up_since/HZ));
+			iter->vsize = vsize;
+			iter->has_swap = ReadProcessSwap(pid, &iter->swap_bytes);
+tttiter->has_io = ReadProcessIO(pid,
+ttttt&iter->io_read_bytes,
+ttttt&iter->io_write_bytes);			process_up_since = (unsigned long long)((unsigned long long)sys_uptime - (process_up_since/HZ));
 			iter->process_up_since_seconds = process_up_since;
 			iter->next = NULL;
 			if (head == NULL)
@@ -295,6 +311,100 @@ void ReadCPUMemoryUsage(int sample)
 	}
 
 	closedir(dirp);
+}
+
+/* Read swap usage from /proc/<pid>/status */
+static bool ReadProcessSwap(int pid, long long unsigned int *swap_bytes)
+{
+	FILE       *fp;
+	char       file_name[MAXPGPATH];
+	char       *line_buf = NULL;
+	size_t     line_buf_size = 0;
+	ssize_t    line_size;
+	bool       found = false;
+
+	snprintf(file_name, MAXPGPATH, "/proc/%d/status", pid);
+	fp = fopen(file_name, "r");
+	if (!fp)
+		return false;
+
+	line_size = getline(&line_buf, &line_buf_size, fp);
+	while (line_size >= 0)
+	{
+		if (strstr(line_buf, "VmSwap:") != NULL)
+		{
+			long long unsigned int val = 0;
+			if (sscanf(line_buf, "VmSwap: %llu", &val) == 1)
+			{
+				*swap_bytes = val * 1024; /* convert kB to bytes */
+				found = true;
+			}
+			break;
+		}
+
+		if (line_buf != NULL)
+		{
+			free(line_buf);
+			line_buf = NULL;
+		}
+		line_size = getline(&line_buf, &line_buf_size, fp);
+	}
+
+	if (line_buf != NULL)
+		free(line_buf);
+
+	fclose(fp);
+	return found;
+}
+
+/* Read IO stats from /proc/<pid>/io */
+static bool ReadProcessIO(int pid,
+		long long unsigned int *read_bytes,
+		long long unsigned int *write_bytes)
+{
+	FILE       *fp;
+	char       file_name[MAXPGPATH];
+	char       *line_buf = NULL;
+	size_t     line_buf_size = 0;
+	ssize_t    line_size;
+	bool       found_read = false;
+	bool       found_write = false;
+
+	snprintf(file_name, MAXPGPATH, "/proc/%d/io", pid);
+	fp = fopen(file_name, "r");
+	if (!fp)
+		return false;
+
+	line_size = getline(&line_buf, &line_buf_size, fp);
+	while (line_size >= 0)
+	{
+ttif (strstr(line_buf, "read_bytes:") != NULL &&
+tttstrstr(line_buf, "cancelled") == NULL)		{
+			if (sscanf(line_buf, "read_bytes: %llu", read_bytes) == 1)
+				found_read = true;
+		}
+ttelse if (strstr(line_buf, "write_bytes:") != NULL &&
+tttstrstr(line_buf, "cancelled") == NULL)		{
+			if (sscanf(line_buf, "write_bytes: %llu", write_bytes) == 1)
+				found_write = true;
+		}
+
+		if (found_read && found_write)
+			break;
+
+		if (line_buf != NULL)
+		{
+			free(line_buf);
+			line_buf = NULL;
+		}
+		line_size = getline(&line_buf, &line_buf_size, fp);
+	}
+
+	if (line_buf != NULL)
+		free(line_buf);
+
+	fclose(fp);
+	return (found_read && found_write);
 }
 
 void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
@@ -350,6 +460,31 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		values[Anum_process_memory_bytes] = UInt64GetDatum((uint64)rss_memory);
 		values[Anum_process_running_since] = UInt64GetDatum((uint64)(running_since));
 
+		/* virtual memory bytes */
+		values[Anum_process_virtual_memory_bytes] =
+			UInt64GetDatum((uint64)(current->vsize));
+
+		/* swap usage */
+		if (current->has_swap)
+			values[Anum_process_swap_usage_bytes] =
+				UInt64GetDatum((uint64)(current->swap_bytes));
+		else
+			nulls[Anum_process_swap_usage_bytes] = true;
+
+		/* IO read/write bytes */
+		if (current->has_io)
+		{
+			values[Anum_process_io_read_bytes] =
+				UInt64GetDatum((uint64)(current->io_read_bytes));
+			values[Anum_process_io_write_bytes] =
+				UInt64GetDatum((uint64)(current->io_write_bytes));
+		}
+		else
+		{
+			nulls[Anum_process_io_read_bytes] = true;
+			nulls[Anum_process_io_write_bytes] = true;
+		}
+
 		tuplestore_putvalues(tupstore, tupdesc, values, nulls);
 
 		//reset the value again
@@ -359,6 +494,9 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		memory_usage = 0.0;
 		running_since = 0;
 		rss_memory = 0;
+		nulls[Anum_process_swap_usage_bytes] = false;
+		nulls[Anum_process_io_read_bytes] = false;
+		nulls[Anum_process_io_write_bytes] = false;
 
 		del_iter = current;
 		current = current->next;

--- a/linux/cpu_memory_by_process.c
+++ b/linux/cpu_memory_by_process.c
@@ -189,6 +189,7 @@ void ReadCPUMemoryUsage(int sample)
 	char  file_name[MAXPGPATH];
 	unsigned long utime_ticks, stime_ticks;
 	char process_name[MAXPGPATH + 1] = {0};
+	char stat_line[4096];
 	int pid = 0;
 	long unsigned int mem_rss = 0;
 	unsigned long long vsize = 0;
@@ -229,14 +230,67 @@ void ReadCPUMemoryUsage(int sample)
 		if (fpstat == NULL)
 			continue;
 
-		if (fscanf(fpstat, "%d %" CppAsString2(MAXPGPATH) "s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %lu"
-					"%lu %*d %*d %*d %*d %*d %*d %llu %llu %lu",
-					&pid, process_name, &utime_ticks, &stime_ticks, &process_up_since, &vsize, &mem_rss) != 7)
+		/*
+		 * Parse /proc/<pid>/stat robustly. The comm field (field 2)
+		 * is wrapped in parentheses and may contain spaces or even
+		 * ')' chars.  The kernel guarantees the first '(' and last
+		 * ')' in the line delimit comm, so we locate those markers
+		 * and sscanf the numeric fields after ')'.
+		 */
+		if (fgets(stat_line, sizeof(stat_line), fpstat) == NULL)
 		{
-			ereport(DEBUG1,
-				(errmsg("Error in parsing file '/proc/%d/stat'", pid)));
 			fclose(fpstat);
 			continue;
+		}
+
+		{
+			char *open_paren;
+			char *close_paren;
+			char *after_comm;
+			size_t name_len;
+
+			open_paren = strchr(stat_line, '(');
+			close_paren = strrchr(stat_line, ')');
+			if (open_paren == NULL || close_paren == NULL ||
+				close_paren <= open_paren)
+			{
+				fclose(fpstat);
+				continue;
+			}
+
+			/* Extract pid from before '(' */
+			if (sscanf(stat_line, "%d", &pid) != 1)
+			{
+				fclose(fpstat);
+				continue;
+			}
+
+			/* Extract comm from between '(' and last ')' */
+			open_paren++;  /* skip '(' */
+			name_len = close_paren - open_paren;
+			if (name_len >= MAXPGPATH)
+				name_len = MAXPGPATH - 1;
+			memcpy(process_name, open_paren, name_len);
+			process_name[name_len] = '\0';
+
+			/* Parse numeric fields after ") " */
+			after_comm = close_paren + 1;
+			if (sscanf(after_comm,
+					   " %*c %*d %*d %*d %*d %*d %*u"
+					   " %*u %*u %*u %*u"
+					   " %lu %lu"
+					   " %*d %*d %*d %*d %*d %*d"
+					   " %llu %llu %lu",
+					   &utime_ticks, &stime_ticks,
+					   &process_up_since, &vsize,
+					   &mem_rss) != 5)
+			{
+				ereport(DEBUG1,
+					(errmsg("Error parsing fields in"
+							" '/proc/%d/stat'", pid)));
+				fclose(fpstat);
+				continue;
+			}
 		}
 
 		if (sample == READ_PROCESS_CPU_USAGE_FIRST_SAMPLE)

--- a/linux/cpu_memory_by_process.c
+++ b/linux/cpu_memory_by_process.c
@@ -243,6 +243,17 @@ void ReadCPUMemoryUsage(int sample)
 			continue;
 		}
 
+		/* Detect truncated lines (no newline and buffer full) */
+		if (strchr(stat_line, '\n') == NULL &&
+			strlen(stat_line) == sizeof(stat_line) - 1)
+		{
+			ereport(DEBUG1,
+				(errmsg("Truncated /proc/%s/stat line",
+						ent->d_name)));
+			fclose(fpstat);
+			continue;
+		}
+
 		{
 			char *open_paren;
 			char *close_paren;
@@ -254,6 +265,10 @@ void ReadCPUMemoryUsage(int sample)
 			if (open_paren == NULL || close_paren == NULL ||
 				close_paren <= open_paren)
 			{
+				ereport(DEBUG1,
+					(errmsg("Malformed /proc/%s/stat:"
+							" missing comm delimiters",
+							ent->d_name)));
 				fclose(fpstat);
 				continue;
 			}
@@ -261,6 +276,10 @@ void ReadCPUMemoryUsage(int sample)
 			/* Extract pid from before '(' */
 			if (sscanf(stat_line, "%d", &pid) != 1)
 			{
+				ereport(DEBUG1,
+					(errmsg("Could not parse PID from"
+							" /proc/%s/stat",
+							ent->d_name)));
 				fclose(fpstat);
 				continue;
 			}
@@ -270,7 +289,8 @@ void ReadCPUMemoryUsage(int sample)
 			name_len = close_paren - open_paren;
 			if (name_len >= MAXPGPATH)
 				name_len = MAXPGPATH - 1;
-			memcpy(process_name, open_paren, name_len);
+			if (name_len > 0)
+				memcpy(process_name, open_paren, name_len);
 			process_name[name_len] = '\0';
 
 			/* Parse numeric fields after ") " */

--- a/linux/cpu_memory_by_process.c
+++ b/linux/cpu_memory_by_process.c
@@ -30,14 +30,14 @@ typedef struct node
 	long long unsigned int process_cpu_sample_1;
 	long long unsigned int process_cpu_sample_2;
 	long long unsigned int rss_memory;
+	unsigned long long process_up_since_seconds;
+	char name[MAXPGPATH];
 	unsigned long long     vsize;
 	long long unsigned int swap_bytes;
 	long long unsigned int io_read_bytes;
 	long long unsigned int io_write_bytes;
 	bool                   has_swap;
 	bool                   has_io;
-	unsigned long long process_up_since_seconds;
-	char name[MAXPGPATH];
 	struct node * next;
 } node_t;
 
@@ -53,8 +53,9 @@ uint64 ReadTotalPhysicalMemory(void);
 uint64 ReadTotalCPUUsage(void);
 /* Function used to read total memory usage for each process */
 void ReadCPUMemoryUsage(int sample);
-/* Forward declarations for process swap and IO reading */
+/* Function used to read swap usage from /proc/<pid>/status */
 static bool ReadProcessSwap(int pid, long long unsigned int *swap_bytes);
+/* Function used to read IO stats from /proc/<pid>/io */
 static bool ReadProcessIO(int pid,
 		long long unsigned int *read_bytes,
 		long long unsigned int *write_bytes);
@@ -214,8 +215,8 @@ void ReadCPUMemoryUsage(int sample)
 	char process_name[MAXPGPATH + 1] = {0};
 	int pid = 0;
 	long unsigned int mem_rss = 0;
-	unsigned  long long  process_up_since = 0;
 	unsigned long long vsize = 0;
+	unsigned  long long  process_up_since = 0;
 	int        HZ = 100;
 	long       tlk = -1;
 	struct     sysinfo s_info;
@@ -243,9 +244,6 @@ void ReadCPUMemoryUsage(int sample)
 	{
 		memset(file_name, 0x00, MAXPGPATH);
 
-		if (!ent)
-			break;
-
 		if (!isdigit(*ent->d_name))
 			continue;
 
@@ -256,8 +254,8 @@ void ReadCPUMemoryUsage(int sample)
 			continue;
 
 		if (fscanf(fpstat, "%d %" CppAsString2(MAXPGPATH) "s %*c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %lu"
-					"%lu %*d %*d %*d %*d %*d %*d %llu %llu %ld",
-					&pid, process_name, &utime_ticks, &stime_ticks, &process_up_since, &vsize, &mem_rss) == EOF)
+					"%lu %*d %*d %*d %*d %*d %*d %llu %llu %lu",
+					&pid, process_name, &utime_ticks, &stime_ticks, &process_up_since, &vsize, &mem_rss) != 7)
 		{
 			ereport(DEBUG1,
 				(errmsg("Error in parsing file '/proc/%d/stat'", pid)));
@@ -273,17 +271,22 @@ void ReadCPUMemoryUsage(int sample)
 				fclose(fpstat);
 				continue;
 			}
+			/* Zero-initialize so process_cpu_sample_2 is 0
+			 * for processes that disappear between samples */
+			memset(iter, 0, sizeof(node_t));
 
 			iter->pid = pid;
 			strncpy(iter->name, process_name, MAXPGPATH);
+			iter->name[MAXPGPATH - 1] = '\0';
 			iter->process_cpu_sample_1 = utime_ticks + stime_ticks;
 			iter->rss_memory = mem_rss;
 			iter->vsize = vsize;
-			iter->has_swap = ReadProcessSwap(pid, &iter->swap_bytes);
-tttiter->has_io = ReadProcessIO(pid,
-ttttt&iter->io_read_bytes,
-ttttt&iter->io_write_bytes);			process_up_since = (unsigned long long)((unsigned long long)sys_uptime - (process_up_since/HZ));
+			process_up_since = (unsigned long long)((unsigned long long)sys_uptime - (process_up_since/HZ));
 			iter->process_up_since_seconds = process_up_since;
+			iter->has_swap = ReadProcessSwap(pid, &iter->swap_bytes);
+			iter->has_io = ReadProcessIO(pid,
+					&iter->io_read_bytes,
+					&iter->io_write_bytes);
 			iter->next = NULL;
 			if (head == NULL)
 				head = iter;
@@ -378,13 +381,15 @@ static bool ReadProcessIO(int pid,
 	line_size = getline(&line_buf, &line_buf_size, fp);
 	while (line_size >= 0)
 	{
-ttif (strstr(line_buf, "read_bytes:") != NULL &&
-tttstrstr(line_buf, "cancelled") == NULL)		{
+		if (strstr(line_buf, "read_bytes:") != NULL &&
+			strstr(line_buf, "cancelled") == NULL)
+		{
 			if (sscanf(line_buf, "read_bytes: %llu", read_bytes) == 1)
 				found_read = true;
 		}
-ttelse if (strstr(line_buf, "write_bytes:") != NULL &&
-tttstrstr(line_buf, "cancelled") == NULL)		{
+		else if (strstr(line_buf, "write_bytes:") != NULL &&
+			strstr(line_buf, "cancelled") == NULL)
+		{
 			if (sscanf(line_buf, "write_bytes: %llu", write_bytes) == 1)
 				found_write = true;
 		}
@@ -431,7 +436,7 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	total_cpu_usage_1 = ReadTotalCPUUsage();
 	/* Read the first sample for cpu and memory usage by each process */
 	ReadCPUMemoryUsage(READ_PROCESS_CPU_USAGE_FIRST_SAMPLE);
-	usleep(100000);
+	pg_usleep(100000);
 	/* Read the second sample for cpu and memory usage by each process */
 	total_cpu_usage_2 = ReadTotalCPUUsage();
 	ReadCPUMemoryUsage(READ_PROCESS_CPU_USAGE_SECOND_SAMPLE);
@@ -446,9 +451,27 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	{
 		process_pid = current->pid;
 		memcpy(command, current->name, MAXPGPATH);
-		cpu_usage = (no_processor) * (current->process_cpu_sample_2 - current->process_cpu_sample_1) * 100 / (float) (total_cpu_usage_2 - total_cpu_usage_1);
+
+		/* Skip if second sample < first (process died/PID reused) */
+		if (current->process_cpu_sample_2 <
+			current->process_cpu_sample_1)
+			cpu_usage = 0.0;
+		/* Guard against div-by-zero or underflow in total CPU */
+		else if (total_cpu_usage_2 <= total_cpu_usage_1)
+			cpu_usage = 0.0;
+		else
+			cpu_usage = (no_processor) *
+				(current->process_cpu_sample_2 -
+				 current->process_cpu_sample_1) *
+				100 / (float)(total_cpu_usage_2 -
+				 total_cpu_usage_1);
+
 		rss_memory = current->rss_memory * page_size_bytes;
-		memory_usage = (rss_memory/(float)total_memory)*100;
+		/* Guard against division by zero when total memory is unavailable */
+		if (total_memory == 0)
+			memory_usage = 0.0;
+		else
+			memory_usage = (rss_memory/(float)total_memory)*100;
 		running_since = current->process_up_since_seconds;
 		memory_usage = fl_round(memory_usage);
 		cpu_usage = fl_round(cpu_usage);

--- a/linux/cpu_memory_by_process.c
+++ b/linux/cpu_memory_by_process.c
@@ -107,23 +107,11 @@ uint64 ReadTotalPhysicalMemory()
 			break;
 		}
 
-		/* Free the allocated line buffer */
-		if (line_buf != NULL)
-		{
-			free(line_buf);
-			line_buf = NULL;
-		}
-
 		/* Get the next line */
 		line_size = getline(&line_buf, &line_buf_size, memory_file);
 	}
 
-	/* Free the allocated line buffer */
-	if (line_buf != NULL)
-	{
-		free(line_buf);
-		line_buf = NULL;
-	}
+	free(line_buf);
 
 	/* Close the file now that we are done with it */
 	fclose(memory_file);
@@ -181,23 +169,11 @@ uint64 ReadTotalCPUUsage()
 			break;
 		}
 
-		/* Free the allocated line buffer */
-		if (line_buf != NULL)
-		{
-			free(line_buf);
-			line_buf = NULL;
-		}
-
 		/* Get the next line */
 		line_size = getline(&line_buf, &line_buf_size, cpu_stats_file);
 	}
 
-	/* Free the allocated line buffer */
-	if (line_buf != NULL)
-	{
-		free(line_buf);
-		line_buf = NULL;
-	}
+	free(line_buf);
 
 	fclose(cpu_stats_file);
 
@@ -345,17 +321,10 @@ static bool ReadProcessSwap(int pid, long long unsigned int *swap_bytes)
 			break;
 		}
 
-		if (line_buf != NULL)
-		{
-			free(line_buf);
-			line_buf = NULL;
-		}
 		line_size = getline(&line_buf, &line_buf_size, fp);
 	}
 
-	if (line_buf != NULL)
-		free(line_buf);
-
+	free(line_buf);
 	fclose(fp);
 	return found;
 }
@@ -397,17 +366,10 @@ static bool ReadProcessIO(int pid,
 		if (found_read && found_write)
 			break;
 
-		if (line_buf != NULL)
-		{
-			free(line_buf);
-			line_buf = NULL;
-		}
 		line_size = getline(&line_buf, &line_buf_size, fp);
 	}
 
-	if (line_buf != NULL)
-		free(line_buf);
-
+	free(line_buf);
 	fclose(fp);
 	return (found_read && found_write);
 }
@@ -437,6 +399,7 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	/* Read the first sample for cpu and memory usage by each process */
 	ReadCPUMemoryUsage(READ_PROCESS_CPU_USAGE_FIRST_SAMPLE);
 	pg_usleep(100000);
+	CHECK_FOR_INTERRUPTS();
 	/* Read the second sample for cpu and memory usage by each process */
 	total_cpu_usage_2 = ReadTotalCPUUsage();
 	ReadCPUMemoryUsage(READ_PROCESS_CPU_USAGE_SECOND_SAMPLE);
@@ -460,10 +423,10 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		else if (total_cpu_usage_2 <= total_cpu_usage_1)
 			cpu_usage = 0.0;
 		else
-			cpu_usage = (no_processor) *
-				(current->process_cpu_sample_2 -
+			cpu_usage = (float)no_processor *
+				(float)(current->process_cpu_sample_2 -
 				 current->process_cpu_sample_1) *
-				100 / (float)(total_cpu_usage_2 -
+				100.0f / (float)(total_cpu_usage_2 -
 				 total_cpu_usage_1);
 
 		rss_memory = current->rss_memory * page_size_bytes;

--- a/sql/system_stats.sql
+++ b/sql/system_stats.sql
@@ -194,7 +194,29 @@ SELECT
 FROM pg_sys_cpu_memory_by_process();
 
 -- ============================================================================
--- Test 11: Multiple calls (test caching and performance)
+-- Test 11: pg_sys_cpu_memory_by_process new columns
+-- ============================================================================
+\echo '### Testing pg_sys_cpu_memory_by_process new columns ###'
+
+-- Verify new columns exist and have correct types
+SELECT
+    pg_typeof(virtual_memory_bytes) = 'bigint'::regtype AS virtual_memory_type_ok,
+    pg_typeof(swap_usage_bytes) = 'bigint'::regtype AS swap_type_ok,
+    pg_typeof(io_read_bytes) = 'bigint'::regtype AS io_read_type_ok,
+    pg_typeof(io_write_bytes) = 'bigint'::regtype AS io_write_type_ok
+FROM pg_sys_cpu_memory_by_process()
+LIMIT 1;
+
+-- Verify at least one process has virtual memory > 0 and no negative values exist
+SELECT
+    count(*) FILTER (WHERE virtual_memory_bytes > 0) > 0 AS has_virtual_memory,
+    count(*) FILTER (WHERE virtual_memory_bytes < 0) = 0 AS no_negative_virtual_memory,
+    count(*) FILTER (WHERE io_read_bytes < 0) = 0 AS no_negative_io_read,
+    count(*) FILTER (WHERE io_write_bytes < 0) = 0 AS no_negative_io_write
+FROM pg_sys_cpu_memory_by_process();
+
+-- ============================================================================
+-- Test 12: Multiple calls (test caching and performance)
 -- ============================================================================
 \echo '### Testing multiple calls (caching) ###'
 
@@ -211,7 +233,7 @@ SELECT
 ;
 
 -- ============================================================================
--- Test 12: Data type verification
+-- Test 13: Data type verification
 -- ============================================================================
 \echo '### Testing data types ###'
 
@@ -230,7 +252,7 @@ SELECT
 FROM pg_sys_cpu_info();
 
 -- ============================================================================
--- Test 13: NULL handling
+-- Test 14: NULL handling
 -- ============================================================================
 \echo '### Testing NULL handling ###'
 

--- a/sql/system_stats.sql
+++ b/sql/system_stats.sql
@@ -211,9 +211,14 @@ LIMIT 1;
 SELECT
     count(*) FILTER (WHERE virtual_memory_bytes > 0) > 0 AS has_virtual_memory,
     count(*) FILTER (WHERE virtual_memory_bytes < 0) = 0 AS no_negative_virtual_memory,
+    count(*) FILTER (WHERE swap_usage_bytes < 0) = 0 AS no_negative_swap,
     count(*) FILTER (WHERE io_read_bytes < 0) = 0 AS no_negative_io_read,
     count(*) FILTER (WHERE io_write_bytes < 0) = 0 AS no_negative_io_write
 FROM pg_sys_cpu_memory_by_process();
+
+-- Verify function returns exactly 10 output columns
+SELECT array_length(proargnames, 1) = 10 AS correct_column_count
+FROM pg_proc WHERE proname = 'pg_sys_cpu_memory_by_process';
 
 -- ============================================================================
 -- Test 12: Multiple calls (test caching and performance)

--- a/sql/upgrade_test.sql
+++ b/sql/upgrade_test.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- Upgrade path test: system_stats 3.0 -> 4.0
+-- ============================================================================
+\echo '### Testing upgrade path 3.0 -> 4.0 ###'
+
+-- Clean slate
+DROP EXTENSION IF EXISTS system_stats CASCADE;
+
+-- Install version 3.0
+CREATE EXTENSION system_stats VERSION '3.0';
+
+-- Verify old function has 6 output columns
+SELECT array_length(proargnames, 1) = 6 AS v3_has_6_columns
+FROM pg_proc WHERE proname = 'pg_sys_cpu_memory_by_process';
+
+-- Verify current version
+SELECT extversion = '3.0' AS is_version_3
+FROM pg_extension WHERE extname = 'system_stats';
+
+-- Upgrade to 4.0
+ALTER EXTENSION system_stats UPDATE TO '4.0';
+
+-- Verify new version
+SELECT extversion = '4.0' AS is_version_4
+FROM pg_extension WHERE extname = 'system_stats';
+
+-- Verify function now has 10 output columns
+SELECT array_length(proargnames, 1) = 10 AS v4_has_10_columns
+FROM pg_proc WHERE proname = 'pg_sys_cpu_memory_by_process';
+
+-- Verify new columns exist with correct types
+SELECT
+    pg_typeof(virtual_memory_bytes) = 'bigint'::regtype AS virtual_memory_type_ok,
+    pg_typeof(swap_usage_bytes) = 'bigint'::regtype AS swap_type_ok,
+    pg_typeof(io_read_bytes) = 'bigint'::regtype AS io_read_type_ok,
+    pg_typeof(io_write_bytes) = 'bigint'::regtype AS io_write_type_ok
+FROM pg_sys_cpu_memory_by_process()
+LIMIT 1;
+
+-- Verify first 6 columns preserved (backward-compatible order)
+SELECT proargnames[1:6] = ARRAY['pid','name','running_since_seconds',
+    'cpu_usage','memory_usage','memory_bytes'] AS first_6_columns_match
+FROM pg_proc WHERE proname = 'pg_sys_cpu_memory_by_process';
+
+-- Clean up
+DROP EXTENSION system_stats;

--- a/system_stats--3.0--4.0.sql
+++ b/system_stats--3.0--4.0.sql
@@ -1,0 +1,29 @@
+-- Upgrade from 3.0 to 4.0
+-- Adds virtual_memory_bytes, swap_usage_bytes, io_read_bytes, io_write_bytes
+-- to pg_sys_cpu_memory_by_process
+--
+-- NOTE: This takes an AccessExclusiveLock on the function.
+-- Run during a maintenance window if the function is actively queried.
+-- Any views or materialized views that depend on the old function
+-- signature must be dropped before running this upgrade.
+
+DROP FUNCTION IF EXISTS pg_sys_cpu_memory_by_process();
+
+CREATE FUNCTION pg_sys_cpu_memory_by_process(
+    OUT pid int,
+    OUT name text,
+    OUT running_since_seconds int8,
+    OUT cpu_usage float4,
+    OUT memory_usage float4,
+    OUT memory_bytes int8,
+    OUT virtual_memory_bytes int8,
+    OUT swap_usage_bytes int8,
+    OUT io_read_bytes int8,
+    OUT io_write_bytes int8
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+REVOKE ALL ON FUNCTION pg_sys_cpu_memory_by_process() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_sys_cpu_memory_by_process() TO monitor_system_stats;

--- a/system_stats--4.0.sql
+++ b/system_stats--4.0.sql
@@ -1,0 +1,221 @@
+/* system statistics extension */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION system_stats" to load this file. \quit
+
+-- role to be assigned while executing functions of system stats
+-- before creating role, check the role exists or not. It may possible
+-- that user want to create extension in multiple database of same server
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'monitor_system_stats') THEN
+        CREATE ROLE monitor_system_stats WITH
+            NOLOGIN
+            NOSUPERUSER
+            NOCREATEDB
+            NOCREATEROLE
+            INHERIT
+            NOREPLICATION
+            CONNECTION LIMIT -1;
+    END IF;
+END
+$$;
+
+-- Operating system information function
+CREATE FUNCTION pg_sys_os_info(
+    OUT name text,
+    OUT version text,
+    OUT host_name text,
+    OUT domain_name text,
+    OUT handle_count int,
+    OUT process_count int,
+    OUT thread_count int,
+    OUT architecture text,
+    OUT last_bootup_time text,
+    OUT os_up_since_seconds int
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+REVOKE ALL ON FUNCTION pg_sys_os_info() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_sys_os_info() TO monitor_system_stats;
+
+-- System CPU information function
+CREATE FUNCTION pg_sys_cpu_info(
+    OUT vendor text,
+    OUT description text,
+    OUT model_name text,
+    OUT processor_type int,
+    OUT logical_processor int,
+    OUT physical_processor int,
+    OUT no_of_cores int,
+    OUT architecture text,
+    OUT clock_speed_hz int8,
+    OUT cpu_type text,
+    OUT cpu_family text,
+    OUT byte_order text,
+    OUT l1dcache_size int,
+    OUT l1icache_size int,
+    OUT l2cache_size int,
+    OUT l3cache_size int
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+REVOKE ALL ON FUNCTION pg_sys_cpu_info() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_sys_cpu_info() TO monitor_system_stats;
+
+-- Memory information function
+CREATE FUNCTION pg_sys_memory_info(
+    OUT total_memory int8,
+    OUT used_memory int8,
+    OUT free_memory int8,
+    OUT swap_total int8,
+    OUT swap_used int8,
+    OUT swap_free int8,
+    OUT cache_total int8,
+    OUT kernel_total int8,
+    OUT kernel_paged int8,
+    OUT kernel_non_paged int8,
+    OUT total_page_file int8,
+    OUT avail_page_file int8
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+REVOKE ALL ON FUNCTION pg_sys_memory_info() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_sys_memory_info() TO monitor_system_stats;
+
+-- Load average information function
+CREATE FUNCTION pg_sys_load_avg_info(
+    OUT load_avg_one_minute float4,
+    OUT load_avg_five_minutes float4,
+    OUT load_avg_ten_minutes float4,
+    OUT load_avg_fifteen_minutes float4
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+REVOKE ALL ON FUNCTION pg_sys_load_avg_info() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_sys_load_avg_info() TO monitor_system_stats;
+
+-- network information function
+CREATE FUNCTION pg_sys_network_info(
+    OUT interface_name text,
+    OUT ip_address text,
+    OUT tx_bytes int8,
+    OUT tx_packets int8,
+    OUT tx_errors int8,
+    OUT tx_dropped int8,
+    OUT rx_bytes int8,
+    OUT rx_packets int8,
+    OUT rx_errors int8,
+    OUT rx_dropped int8,
+    OUT link_speed_mbps int
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+REVOKE ALL ON FUNCTION pg_sys_network_info() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_sys_network_info() TO monitor_system_stats;
+
+-- CPU and memory information by process id or name
+CREATE FUNCTION pg_sys_cpu_memory_by_process(
+    OUT pid int,
+    OUT name text,
+    OUT running_since_seconds int8,
+    OUT cpu_usage float4,
+    OUT memory_usage float4,
+    OUT memory_bytes int8,
+    OUT virtual_memory_bytes int8,
+    OUT swap_usage_bytes int8,
+    OUT io_read_bytes int8,
+    OUT io_write_bytes int8
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+REVOKE ALL ON FUNCTION pg_sys_cpu_memory_by_process() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_sys_cpu_memory_by_process() TO monitor_system_stats;
+
+-- Disk information function
+CREATE FUNCTION pg_sys_disk_info(
+    OUT mount_point text,
+    OUT file_system text,
+    OUT drive_letter text,
+    OUT drive_type int,
+    OUT file_system_type text,
+    OUT total_space int8,
+    OUT used_space int8,
+    OUT free_space int8,
+    OUT total_inodes int8,
+    OUT used_inodes int8,
+    OUT free_inodes int8
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+REVOKE ALL ON FUNCTION pg_sys_disk_info() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_sys_disk_info() TO monitor_system_stats;
+
+-- process information function
+CREATE FUNCTION pg_sys_process_info(
+    OUT total_processes int,
+    OUT running_processes int,
+    OUT sleeping_processes int,
+    OUT stopped_processes int,
+    OUT zombie_processes int
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+REVOKE ALL ON FUNCTION pg_sys_process_info() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_sys_process_info() TO monitor_system_stats;
+
+-- CPU usage information function
+-- This function will fetch the time spent in percentage by CPU in each mode
+-- as described by arguments
+CREATE FUNCTION pg_sys_cpu_usage_info(
+    OUT usermode_normal_process_percent float4,
+    OUT usermode_niced_process_percent float4,
+    OUT kernelmode_process_percent float4,
+    OUT idle_mode_percent float4,
+    OUT IO_completion_percent float4,
+    OUT servicing_irq_percent float4,
+    OUT servicing_softirq_percent float4,
+    OUT user_time_percent float4,
+    OUT processor_time_percent float4,
+    OUT privileged_time_percent float4,
+    OUT interrupt_time_percent float4
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+REVOKE ALL ON FUNCTION pg_sys_cpu_usage_info() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_sys_cpu_usage_info() TO monitor_system_stats;
+
+-- IO analysis information function
+CREATE FUNCTION pg_sys_io_analysis_info(
+	OUT device_name text,
+	OUT total_reads int8,
+	OUT total_writes int8,
+	OUT read_bytes int8,
+	OUT write_bytes int8,
+	OUT read_time_ms int8,
+	OUT write_time_ms int8
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+REVOKE ALL ON FUNCTION pg_sys_io_analysis_info() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION pg_sys_io_analysis_info() TO monitor_system_stats;

--- a/system_stats.c
+++ b/system_stats.c
@@ -26,7 +26,7 @@
 #include "utils/timestamp.h"
 
 #ifdef PG_MODULE_MAGIC_EXT
-PG_MODULE_MAGIC_EXT(.name = "system_stats", .version = "3.2.1");
+PG_MODULE_MAGIC_EXT(.name = "system_stats", .version = "4.0");
 #else
 PG_MODULE_MAGIC;
 #endif

--- a/system_stats.control
+++ b/system_stats.control
@@ -1,5 +1,5 @@
 # system_stats extension
 comment = 'EnterpriseDB system statistics for PostgreSQL'
-default_version = '3.0'
+default_version = '4.0'
 module_pathname = '$libdir/system_stats'
 relocatable = true

--- a/system_stats.h
+++ b/system_stats.h
@@ -210,12 +210,16 @@ int is_process_running(int pid);
 
 /* Macros for cpu and memory information
  * by process*/
-#define Natts_cpu_memory_info_by_process         6
+#define Natts_cpu_memory_info_by_process         10
 #define Anum_process_pid                         0
 #define Anum_process_name                        1
 #define Anum_process_running_since               2
 #define Anum_percent_cpu_usage                   3
 #define Anum_percent_memory_usage                4
 #define Anum_process_memory_bytes                5
+#define Anum_process_virtual_memory_bytes         6
+#define Anum_process_swap_usage_bytes             7
+#define Anum_process_io_read_bytes                8
+#define Anum_process_io_write_bytes               9
 
 #endif // SYSTEM_STATS_H

--- a/system_stats.h
+++ b/system_stats.h
@@ -15,6 +15,7 @@
 #include <wbemidl.h>
 #endif
 
+#include "miscadmin.h"
 #include "access/tupdesc.h"
 #include "utils/tuplestore.h"
 #include "utils/builtins.h"

--- a/windows/cpu_memory_by_process.c
+++ b/windows/cpu_memory_by_process.c
@@ -53,14 +53,14 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		// enumerate the retrieved objects
 		while ((hres = results->lpVtbl->Next(results, WBEM_INFINITE, 1, &result, &returnedCount)) == S_OK)
 		{
-			/* Reset null flags for each process to prevent NULL propagation */
-			memset(nulls, 0, sizeof(nulls));
-
 			VARIANT query_result;
 
 			int     wstr_length = 0;
 			char    *dst = NULL;
 			size_t  charsConverted = 0;
+
+			/* Reset null flags for each process to prevent NULL propagation from previous rows */
+			memset(nulls, 0, sizeof(nulls));
 
 			/* Get the value from query output */
 			hres = result->lpVtbl->Get(result, L"IDProcess", 0, &query_result, 0, 0);
@@ -84,10 +84,19 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				else
 				{
 					dst = (char *)malloc(wstr_length + 10);
-					memset(dst, 0x00, (wstr_length + 10));
-					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-					values[Anum_process_name] = CStringGetTextDatum(dst);
-					free(dst);
+					if (dst == NULL)
+					{
+						nulls[Anum_process_name] = true;
+						VariantClear(&query_result);
+					}
+					else
+					{
+						memset(dst, 0x00, (wstr_length + 10));
+						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
+						values[Anum_process_name] = CStringGetTextDatum(dst);
+						free(dst);
+						VariantClear(&query_result);
+					}
 				}
 				VariantClear(&query_result);
 			}
@@ -105,11 +114,20 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				else
 				{
 					dst = (char *)malloc(wstr_length + 10);
-					memset(dst, 0x00, (wstr_length + 10));
-					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-					long long val = strtoll(dst, NULL, 10);
-					values[Anum_process_running_since] = UInt64GetDatum(val);
-					free(dst);
+					if (dst == NULL)
+					{
+						nulls[Anum_process_running_since] = true;
+						VariantClear(&query_result);
+					}
+					else
+					{
+						memset(dst, 0x00, (wstr_length + 10));
+						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
+						long long val = strtoll(dst, NULL, 10);
+						values[Anum_process_running_since] = UInt64GetDatum(val);
+						free(dst);
+						VariantClear(&query_result);
+					}
 				}
 				VariantClear(&query_result);
 			}
@@ -127,45 +145,70 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				else
 				{
 					dst = (char *)malloc(wstr_length + 10);
-					memset(dst, 0x00, (wstr_length + 10));
-					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-					long long val = strtoll(dst, NULL, 10);
-					float4 cpu_usage_per = (float4)val;
-					values[Anum_percent_cpu_usage] = Float4GetDatum(cpu_usage_per);
-					free(dst);
+					if (dst == NULL)
+					{
+						nulls[Anum_percent_cpu_usage] = true;
+						VariantClear(&query_result);
+					}
+					else
+					{
+						memset(dst, 0x00, (wstr_length + 10));
+						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
+						long long val = strtoll(dst, NULL, 10);
+						float4 cpu_usage_per = (float4)val;
+						values[Anum_percent_cpu_usage] = Float4GetDatum(cpu_usage_per);
+						free(dst);
+						VariantClear(&query_result);
+					}
 				}
 				VariantClear(&query_result);
 			}
 
 			hres = result->lpVtbl->Get(result, L"WorkingSetPrivate", 0, &query_result, 0, 0);
 			if (FAILED(hres))
+			{
 				nulls[Anum_percent_memory_usage] = true;
+				nulls[Anum_process_memory_bytes] = true;
+			}
 			else
 			{
 				wstr_length = 0;
 				charsConverted = 0;
 				wstr_length = SysStringLen(query_result.bstrVal);
 				if (wstr_length == 0)
+				{
 					nulls[Anum_percent_memory_usage] = true;
+					nulls[Anum_process_memory_bytes] = true;
+				}
 				else
 				{
 					dst = (char *)malloc(wstr_length + 10);
-					memset(dst, 0x00, (wstr_length + 10));
-					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-					long long val = strtoll(dst, NULL, 10);
-					values[Anum_process_memory_bytes] = UInt64GetDatum(val);
-					float4 memory_usage_per = (float4)(val / total_physical_memory) * 100;
-					values[Anum_percent_memory_usage] = Float4GetDatum(memory_usage_per);
-					free(dst);
+					if (dst == NULL)
+					{
+						nulls[Anum_percent_memory_usage] = true;
+						nulls[Anum_process_memory_bytes] = true;
+						VariantClear(&query_result);
+					}
+					else
+					{
+						memset(dst, 0x00, (wstr_length + 10));
+						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
+						long long val = strtoll(dst, NULL, 10);
+						values[Anum_process_memory_bytes] = UInt64GetDatum(val);
+						/* Cast to float before division to avoid integer truncation */
+						float4 memory_usage_per;
+						if (total_physical_memory == 0)
+							memory_usage_per = 0.0;
+						else
+							memory_usage_per = ((float4)val / (float4)total_physical_memory) * 100;
+						values[Anum_percent_memory_usage] = Float4GetDatum(memory_usage_per);
+						free(dst);
+						VariantClear(&query_result);
+					}
 				}
 				VariantClear(&query_result);
 			}
 
-			/*
-			 * NOTE: On Windows, PageFileBytes represents committed memory backed
-			 * by the page file, not just memory actively swapped out to disk.
-			 * This differs from Linux VmSwap which only counts memory on swap.
-			 */
 			hres = result->lpVtbl->Get(result, L"VirtualBytes", 0, &query_result, 0, 0);
 			if (FAILED(hres))
 				nulls[Anum_process_virtual_memory_bytes] = true;
@@ -179,15 +222,29 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				else
 				{
 					dst = (char *)malloc(wstr_length + 10);
-					memset(dst, 0x00, (wstr_length + 10));
-					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-					long long val = strtoll(dst, NULL, 10);
-					values[Anum_process_virtual_memory_bytes] = UInt64GetDatum(val);
-					free(dst);
+					if (dst == NULL)
+					{
+						nulls[Anum_process_virtual_memory_bytes] = true;
+						VariantClear(&query_result);
+					}
+					else
+					{
+						memset(dst, 0x00, (wstr_length + 10));
+						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
+						long long val = strtoll(dst, NULL, 10);
+						values[Anum_process_virtual_memory_bytes] = UInt64GetDatum(val);
+						free(dst);
+						VariantClear(&query_result);
+					}
 				}
 				VariantClear(&query_result);
 			}
 
+			/*
+			 * NOTE: PageFileBytes represents committed memory backed by the page file,
+			 * not just memory actively swapped out. This differs from Linux VmSwap
+			 * which only counts memory actually on swap disk.
+			 */
 			hres = result->lpVtbl->Get(result, L"PageFileBytes", 0, &query_result, 0, 0);
 			if (FAILED(hres))
 				nulls[Anum_process_swap_usage_bytes] = true;
@@ -201,21 +258,31 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				else
 				{
 					dst = (char *)malloc(wstr_length + 10);
-					memset(dst, 0x00, (wstr_length + 10));
-					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-					long long val = strtoll(dst, NULL, 10);
-					values[Anum_process_swap_usage_bytes] = UInt64GetDatum(val);
-					free(dst);
+					if (dst == NULL)
+					{
+						nulls[Anum_process_swap_usage_bytes] = true;
+						VariantClear(&query_result);
+					}
+					else
+					{
+						memset(dst, 0x00, (wstr_length + 10));
+						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
+						long long val = strtoll(dst, NULL, 10);
+						values[Anum_process_swap_usage_bytes] = UInt64GetDatum(val);
+						free(dst);
+						VariantClear(&query_result);
+					}
 				}
 				VariantClear(&query_result);
 			}
 
 			/*
-			 * NOTE: IOReadBytesPerSec and IOWriteBytesPerSec from
+			 * NOTE: On Windows, IOReadBytesPerSec and IOWriteBytesPerSec from
 			 * Win32_PerfFormattedData_PerfProc_Process are per-second rates,
 			 * while Linux (/proc/<pid>/io) and macOS (proc_pid_rusage) return
-			 * cumulative byte totals. This cross-platform semantic difference
-			 * is a known limitation.
+			 * cumulative totals. This semantic difference is a known limitation.
+			 * To get cumulative totals, a separate WMI query to Win32_Process
+			 * for ReadTransferCount/WriteTransferCount would be needed.
 			 */
 			hres = result->lpVtbl->Get(result, L"IOReadBytesPerSec", 0, &query_result, 0, 0);
 			if (FAILED(hres))
@@ -230,11 +297,20 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				else
 				{
 					dst = (char *)malloc(wstr_length + 10);
-					memset(dst, 0x00, (wstr_length + 10));
-					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-					long long val = strtoll(dst, NULL, 10);
-					values[Anum_process_io_read_bytes] = UInt64GetDatum(val);
-					free(dst);
+					if (dst == NULL)
+					{
+						nulls[Anum_process_io_read_bytes] = true;
+						VariantClear(&query_result);
+					}
+					else
+					{
+						memset(dst, 0x00, (wstr_length + 10));
+						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
+						long long val = strtoll(dst, NULL, 10);
+						values[Anum_process_io_read_bytes] = UInt64GetDatum(val);
+						free(dst);
+						VariantClear(&query_result);
+					}
 				}
 				VariantClear(&query_result);
 			}
@@ -252,11 +328,20 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				else
 				{
 					dst = (char *)malloc(wstr_length + 10);
-					memset(dst, 0x00, (wstr_length + 10));
-					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-					long long val = strtoll(dst, NULL, 10);
-					values[Anum_process_io_write_bytes] = UInt64GetDatum(val);
-					free(dst);
+					if (dst == NULL)
+					{
+						nulls[Anum_process_io_write_bytes] = true;
+						VariantClear(&query_result);
+					}
+					else
+					{
+						memset(dst, 0x00, (wstr_length + 10));
+						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
+						long long val = strtoll(dst, NULL, 10);
+						values[Anum_process_io_write_bytes] = UInt64GetDatum(val);
+						free(dst);
+						VariantClear(&query_result);
+					}
 				}
 				VariantClear(&query_result);
 			}

--- a/windows/cpu_memory_by_process.c
+++ b/windows/cpu_memory_by_process.c
@@ -85,17 +85,13 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				{
 					dst = (char *)malloc(wstr_length + 10);
 					if (dst == NULL)
-					{
 						nulls[Anum_process_name] = true;
-						VariantClear(&query_result);
-					}
 					else
 					{
 						memset(dst, 0x00, (wstr_length + 10));
 						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
 						values[Anum_process_name] = CStringGetTextDatum(dst);
 						free(dst);
-						VariantClear(&query_result);
 					}
 				}
 				VariantClear(&query_result);
@@ -115,18 +111,14 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				{
 					dst = (char *)malloc(wstr_length + 10);
 					if (dst == NULL)
-					{
 						nulls[Anum_process_running_since] = true;
-						VariantClear(&query_result);
-					}
 					else
 					{
 						memset(dst, 0x00, (wstr_length + 10));
 						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-						long long val = strtoll(dst, NULL, 10);
+						unsigned long long val = strtoull(dst, NULL, 10);
 						values[Anum_process_running_since] = UInt64GetDatum(val);
 						free(dst);
-						VariantClear(&query_result);
 					}
 				}
 				VariantClear(&query_result);
@@ -146,10 +138,7 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				{
 					dst = (char *)malloc(wstr_length + 10);
 					if (dst == NULL)
-					{
 						nulls[Anum_percent_cpu_usage] = true;
-						VariantClear(&query_result);
-					}
 					else
 					{
 						memset(dst, 0x00, (wstr_length + 10));
@@ -158,7 +147,6 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 						float4 cpu_usage_per = (float4)val;
 						values[Anum_percent_cpu_usage] = Float4GetDatum(cpu_usage_per);
 						free(dst);
-						VariantClear(&query_result);
 					}
 				}
 				VariantClear(&query_result);
@@ -187,13 +175,12 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					{
 						nulls[Anum_percent_memory_usage] = true;
 						nulls[Anum_process_memory_bytes] = true;
-						VariantClear(&query_result);
 					}
 					else
 					{
 						memset(dst, 0x00, (wstr_length + 10));
 						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-						long long val = strtoll(dst, NULL, 10);
+						unsigned long long val = strtoull(dst, NULL, 10);
 						values[Anum_process_memory_bytes] = UInt64GetDatum(val);
 						/* Cast to float before division to avoid integer truncation */
 						float4 memory_usage_per;
@@ -203,7 +190,6 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 							memory_usage_per = ((float4)val / (float4)total_physical_memory) * 100;
 						values[Anum_percent_memory_usage] = Float4GetDatum(memory_usage_per);
 						free(dst);
-						VariantClear(&query_result);
 					}
 				}
 				VariantClear(&query_result);
@@ -223,18 +209,14 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				{
 					dst = (char *)malloc(wstr_length + 10);
 					if (dst == NULL)
-					{
 						nulls[Anum_process_virtual_memory_bytes] = true;
-						VariantClear(&query_result);
-					}
 					else
 					{
 						memset(dst, 0x00, (wstr_length + 10));
 						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-						long long val = strtoll(dst, NULL, 10);
+						unsigned long long val = strtoull(dst, NULL, 10);
 						values[Anum_process_virtual_memory_bytes] = UInt64GetDatum(val);
 						free(dst);
-						VariantClear(&query_result);
 					}
 				}
 				VariantClear(&query_result);
@@ -259,18 +241,14 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				{
 					dst = (char *)malloc(wstr_length + 10);
 					if (dst == NULL)
-					{
 						nulls[Anum_process_swap_usage_bytes] = true;
-						VariantClear(&query_result);
-					}
 					else
 					{
 						memset(dst, 0x00, (wstr_length + 10));
 						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-						long long val = strtoll(dst, NULL, 10);
+						unsigned long long val = strtoull(dst, NULL, 10);
 						values[Anum_process_swap_usage_bytes] = UInt64GetDatum(val);
 						free(dst);
-						VariantClear(&query_result);
 					}
 				}
 				VariantClear(&query_result);
@@ -298,18 +276,14 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				{
 					dst = (char *)malloc(wstr_length + 10);
 					if (dst == NULL)
-					{
 						nulls[Anum_process_io_read_bytes] = true;
-						VariantClear(&query_result);
-					}
 					else
 					{
 						memset(dst, 0x00, (wstr_length + 10));
 						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-						long long val = strtoll(dst, NULL, 10);
+						unsigned long long val = strtoull(dst, NULL, 10);
 						values[Anum_process_io_read_bytes] = UInt64GetDatum(val);
 						free(dst);
-						VariantClear(&query_result);
 					}
 				}
 				VariantClear(&query_result);
@@ -329,18 +303,14 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				{
 					dst = (char *)malloc(wstr_length + 10);
 					if (dst == NULL)
-					{
 						nulls[Anum_process_io_write_bytes] = true;
-						VariantClear(&query_result);
-					}
 					else
 					{
 						memset(dst, 0x00, (wstr_length + 10));
 						wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
-						long long val = strtoll(dst, NULL, 10);
+						unsigned long long val = strtoull(dst, NULL, 10);
 						values[Anum_process_io_write_bytes] = UInt64GetDatum(val);
 						free(dst);
-						VariantClear(&query_result);
 					}
 				}
 				VariantClear(&query_result);

--- a/windows/cpu_memory_by_process.c
+++ b/windows/cpu_memory_by_process.c
@@ -53,6 +53,9 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		// enumerate the retrieved objects
 		while ((hres = results->lpVtbl->Next(results, WBEM_INFINITE, 1, &result, &returnedCount)) == S_OK)
 		{
+			/* Reset null flags for each process to prevent NULL propagation */
+			memset(nulls, 0, sizeof(nulls));
+
 			VARIANT query_result;
 
 			int     wstr_length = 0;
@@ -153,6 +156,106 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 					values[Anum_process_memory_bytes] = UInt64GetDatum(val);
 					float4 memory_usage_per = (float4)(val / total_physical_memory) * 100;
 					values[Anum_percent_memory_usage] = Float4GetDatum(memory_usage_per);
+					free(dst);
+				}
+				VariantClear(&query_result);
+			}
+
+			/*
+			 * NOTE: On Windows, PageFileBytes represents committed memory backed
+			 * by the page file, not just memory actively swapped out to disk.
+			 * This differs from Linux VmSwap which only counts memory on swap.
+			 */
+			hres = result->lpVtbl->Get(result, L"VirtualBytes", 0, &query_result, 0, 0);
+			if (FAILED(hres))
+				nulls[Anum_process_virtual_memory_bytes] = true;
+			else
+			{
+				wstr_length = 0;
+				charsConverted = 0;
+				wstr_length = SysStringLen(query_result.bstrVal);
+				if (wstr_length == 0)
+					nulls[Anum_process_virtual_memory_bytes] = true;
+				else
+				{
+					dst = (char *)malloc(wstr_length + 10);
+					memset(dst, 0x00, (wstr_length + 10));
+					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
+					long long val = strtoll(dst, NULL, 10);
+					values[Anum_process_virtual_memory_bytes] = UInt64GetDatum(val);
+					free(dst);
+				}
+				VariantClear(&query_result);
+			}
+
+			hres = result->lpVtbl->Get(result, L"PageFileBytes", 0, &query_result, 0, 0);
+			if (FAILED(hres))
+				nulls[Anum_process_swap_usage_bytes] = true;
+			else
+			{
+				wstr_length = 0;
+				charsConverted = 0;
+				wstr_length = SysStringLen(query_result.bstrVal);
+				if (wstr_length == 0)
+					nulls[Anum_process_swap_usage_bytes] = true;
+				else
+				{
+					dst = (char *)malloc(wstr_length + 10);
+					memset(dst, 0x00, (wstr_length + 10));
+					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
+					long long val = strtoll(dst, NULL, 10);
+					values[Anum_process_swap_usage_bytes] = UInt64GetDatum(val);
+					free(dst);
+				}
+				VariantClear(&query_result);
+			}
+
+			/*
+			 * NOTE: IOReadBytesPerSec and IOWriteBytesPerSec from
+			 * Win32_PerfFormattedData_PerfProc_Process are per-second rates,
+			 * while Linux (/proc/<pid>/io) and macOS (proc_pid_rusage) return
+			 * cumulative byte totals. This cross-platform semantic difference
+			 * is a known limitation.
+			 */
+			hres = result->lpVtbl->Get(result, L"IOReadBytesPerSec", 0, &query_result, 0, 0);
+			if (FAILED(hres))
+				nulls[Anum_process_io_read_bytes] = true;
+			else
+			{
+				wstr_length = 0;
+				charsConverted = 0;
+				wstr_length = SysStringLen(query_result.bstrVal);
+				if (wstr_length == 0)
+					nulls[Anum_process_io_read_bytes] = true;
+				else
+				{
+					dst = (char *)malloc(wstr_length + 10);
+					memset(dst, 0x00, (wstr_length + 10));
+					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
+					long long val = strtoll(dst, NULL, 10);
+					values[Anum_process_io_read_bytes] = UInt64GetDatum(val);
+					free(dst);
+				}
+				VariantClear(&query_result);
+			}
+
+			hres = result->lpVtbl->Get(result, L"IOWriteBytesPerSec", 0, &query_result, 0, 0);
+			if (FAILED(hres))
+				nulls[Anum_process_io_write_bytes] = true;
+			else
+			{
+				wstr_length = 0;
+				charsConverted = 0;
+				wstr_length = SysStringLen(query_result.bstrVal);
+				if (wstr_length == 0)
+					nulls[Anum_process_io_write_bytes] = true;
+				else
+				{
+					dst = (char *)malloc(wstr_length + 10);
+					memset(dst, 0x00, (wstr_length + 10));
+					wcstombs_s(&charsConverted, dst, wstr_length + 10, query_result.bstrVal, wstr_length);
+					long long val = strtoll(dst, NULL, 10);
+					values[Anum_process_io_write_bytes] = UInt64GetDatum(val);
 					free(dst);
 				}
 				VariantClear(&query_result);


### PR DESCRIPTION
## Summary

- Extend `pg_sys_cpu_memory_by_process()` from 6 to 10 output columns, adding per-process `virtual_memory_bytes`, `swap_usage_bytes`, `io_read_bytes`, and `io_write_bytes`
- Fix multiple pre-existing bugs in `cpu_memory_by_process` across all platforms (division by zero, buffer over-reads, uninitialized memory, operator precedence, NULL propagation)
- Add SQL v4.0 install and 3.0→4.0 upgrade scripts with regression tests

### Context

Migration to CNPG (Cloud Native Postgres), where PEM agent is unavailable in Kubernetes environments. These metrics provide database-native session-level resource telemetry.

### New Columns

| Column | Type | Linux | macOS | Windows |
|--------|------|-------|-------|---------|
| `virtual_memory_bytes` | int8 | `/proc/<pid>/stat` vsize | `pti_virtual_size` | WMI `VirtualBytes` |
| `swap_usage_bytes` | int8 | `/proc/<pid>/status` VmSwap | NULL | WMI `PageFileBytes` |
| `io_read_bytes` | int8 | `/proc/<pid>/io` | `proc_pid_rusage` | WMI `IOReadBytesPerSec` |
| `io_write_bytes` | int8 | `/proc/<pid>/io` | `proc_pid_rusage` | WMI `IOWriteBytesPerSec` |

Function name unchanged; new columns are purely additive. Existing queries work without modification.

### Known Cross-Platform Semantic Differences (documented in code)

- **swap_usage_bytes**: Linux reports actual swapped-out memory (`VmSwap`); Windows reports committed page-file-backed memory (`PageFileBytes`); macOS returns NULL
- **io_read/write_bytes**: Linux/macOS return cumulative totals; Windows returns per-second rates (`IOReadBytesPerSec`/`IOWriteBytesPerSec`)

### Pre-existing Bug Fixes (second commit)

- **Linux**: Division-by-zero guards, fscanf return/format fixes, malloc zero-init, pg_usleep, strncpy null-termination
- **macOS**: Operator precedence bug, memcpy buffer over-read (p_comm 17 bytes read as 1024), integer division truncation, uninitialized total_memory, pg_usleep
- **Windows**: Integer division always-zero memory_usage, WorkingSetPrivate incomplete NULL handling, malloc NULL checks

## Test Plan

- [x] `make clean && make` compiles with zero errors on macOS
- [x] `make installcheck` passes 2/2 regression tests
- [x] Fresh install: `CREATE EXTENSION system_stats` creates 10-column function
- [x] Upgrade path: `CREATE EXTENSION system_stats VERSION '3.0'; ALTER EXTENSION system_stats UPDATE TO '4.0';`
- [x] New columns populated: `SELECT pid, virtual_memory_bytes, swap_usage_bytes, io_read_bytes, io_write_bytes FROM pg_sys_cpu_memory_by_process() LIMIT 5;`
- [ ] Linux CI build verification
- [ ] Windows build verification