### PR TITLE
Fix security vulnerabilities identified by Codacy static analysis

### DIFF
--- a/darwin/cpu_memory_by_process.c
+++ b/darwin/cpu_memory_by_process.c
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <unistd.h>
+#include <time.h>
 
 #include <mach/mach.h>
 #include <mach/vm_page_size.h>
@@ -82,7 +83,7 @@ void CreateCPUMemoryList(int sample)
 
 			memset(iter, 0x00, sizeof(node_t));
 			iter->pid = proclist->kp_proc.p_pid;
-			memcpy(iter->name, proclist->kp_proc.p_comm, MAXPGPATH);
+			strlcpy(iter->name, proclist->kp_proc.p_comm, MAXPGPATH);
 			if ((ret_val <= 0) || ((unsigned long)ret_val < sizeof(pti)))
 				iter->process_owned_by_user = 0;
 			else
@@ -160,7 +161,10 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	total_cpu_usage_1 = find_cpu_times();
 	/* Read the first sample for cpu and memory usage by each process */
 	CreateCPUMemoryList(READ_PROCESS_CPU_USAGE_FIRST_SAMPLE);
-	usleep(100000);
+	{
+		struct timespec ts = {0, 100000000L};
+		nanosleep(&ts, NULL);
+	}
 	/* Read the second sample for cpu and memory usage by each process */
 	total_cpu_usage_2 = find_cpu_times();
 	CreateCPUMemoryList(READ_PROCESS_CPU_USAGE_SECOND_SAMPLE);

--- a/darwin/cpu_usage_info.c
+++ b/darwin/cpu_usage_info.c
@@ -11,6 +11,7 @@
 #include "system_stats.h"
 
 #include <unistd.h>
+#include <time.h>
 #include <sys/sysctl.h>
 #include <mach/mach_host.h>
 #include <mach/host_info.h>
@@ -63,8 +64,11 @@ void ReadCPUUsageStatistics(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		return;
 	}
 
-	/* sleep for the 100ms between 2 samples tp find cpu usage statistics */
-	usleep(100000);
+	/* sleep for 100ms between 2 samples to find cpu usage statistics */
+	{
+		struct timespec ts = {0, 100000000L};
+		nanosleep(&ts, NULL);
+	}
 	/* Take the second sample regarding cpu usage statistics */
 	if (cpu_stat_information(&second_sample))
 	{

--- a/linux/cpu_info.c
+++ b/linux/cpu_info.c
@@ -147,25 +147,25 @@ void ReadCPUInformation(Tuplestorestate *tupstore, TupleDesc tupdesc)
 				if (strlen(line_buf) > 0)
 				{
 					found = strstr(line_buf, ":");
-					if (strlen(found) > 0)
+					if (found != NULL && strlen(found) > 0)
 					{
 						found = trimStr((found+1));
 
 						if (strstr(line_buf, "vendor_id") != NULL)
-							memcpy(vendor_id, found, strlen(found));
+							strlcpy(vendor_id, found, MAXPGPATH);
 						if (strstr(line_buf, "cpu family") != NULL)
-							memcpy(cpu_family, found, strlen(found));
+							strlcpy(cpu_family, found, MAXPGPATH);
 						if (strstr(line_buf, "model") != NULL && !model_found)
 						{
-							memcpy(model, found, strlen(found));
+							strlcpy(model, found, MAXPGPATH);
 							model_found = true;
 						}
 						if (strstr(line_buf, "model name") != NULL)
-							memcpy(model_name, found, strlen(found));
+							strlcpy(model_name, found, MAXPGPATH);
 						if (strstr(line_buf, "cpu MHz") != NULL)
 						{
 							physical_processor++;
-							memcpy(cpu_mhz, found, strlen(found));
+							strlcpy(cpu_mhz, found, MAXPGPATH);
 						}
 						if (strstr(line_buf, "cpu cores") != NULL)
 							cpu_cores = atoi(found);

--- a/linux/cpu_memory_by_process.c
+++ b/linux/cpu_memory_by_process.c
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 #include <string.h>
 #include <unistd.h>
+#include <time.h>
 #include <dirent.h>
 #include <ctype.h>
 #include <sys/sysinfo.h>
@@ -263,7 +264,7 @@ void ReadCPUMemoryUsage(int sample)
 			}
 
 			iter->pid = pid;
-			strncpy(iter->name, process_name, MAXPGPATH);
+			strlcpy(iter->name, process_name, MAXPGPATH);
 			iter->process_cpu_sample_1 = utime_ticks + stime_ticks;
 			iter->rss_memory = mem_rss;
 			process_up_since = (unsigned long long)((unsigned long long)sys_uptime - (process_up_since/HZ));
@@ -321,7 +322,10 @@ void ReadCPUMemoryByProcess(Tuplestorestate *tupstore, TupleDesc tupdesc)
 	total_cpu_usage_1 = ReadTotalCPUUsage();
 	/* Read the first sample for cpu and memory usage by each process */
 	ReadCPUMemoryUsage(READ_PROCESS_CPU_USAGE_FIRST_SAMPLE);
-	usleep(100000);
+	{
+		struct timespec ts = {0, 100000000L};
+		nanosleep(&ts, NULL);
+	}
 	/* Read the second sample for cpu and memory usage by each process */
 	total_cpu_usage_2 = ReadTotalCPUUsage();
 	ReadCPUMemoryUsage(READ_PROCESS_CPU_USAGE_SECOND_SAMPLE);

--- a/linux/cpu_usage_info.c
+++ b/linux/cpu_usage_info.c
@@ -11,6 +11,7 @@
 #include "system_stats.h"
 
 #include <unistd.h>
+#include <time.h>
 
 void ReadCPUUsageStatistics(Tuplestorestate *tupstore, TupleDesc tupdesc);
 
@@ -137,8 +138,11 @@ void ReadCPUUsageStatistics(Tuplestorestate *tupstore, TupleDesc tupdesc)
 
 	/* Take the first sample regarding cpu usage statistics */
 	cpu_stat_information(&first_sample);
-	/* sleep for the 100ms between 2 samples tp find cpu usage statistics */
-	usleep(150000);
+	/* sleep for 150ms between 2 samples to find cpu usage statistics */
+	{
+		struct timespec ts = {0, 150000000L};
+		nanosleep(&ts, NULL);
+	}
 	/* Take the second sample regarding cpu usage statistics */
 	cpu_stat_information(&second_sample);
 

--- a/linux/os_info.c
+++ b/linux/os_info.c
@@ -264,9 +264,8 @@ void ReadOSInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 		/* Loop through until we are done with the file. */
 		while (line_size >= 0)
 		{
-			int len = strlen(line_buf);
 			if (strstr(line_buf, OS_DESC_SEARCH_TEXT) != NULL)
-				memcpy(os_name, remove_quotes(str_trim(line_buf + strlen(OS_DESC_SEARCH_TEXT))), (len - strlen(OS_DESC_SEARCH_TEXT)));
+				strlcpy(os_name, remove_quotes(str_trim(line_buf + strlen(OS_DESC_SEARCH_TEXT))), MAXPGPATH);
 
 			/* Free the allocated line buffer */
 			if (line_buf != NULL)

--- a/windows/network_info.c
+++ b/windows/network_info.c
@@ -100,7 +100,7 @@ void ReadNetworkInformations(Tuplestorestate *tupstore, TupleDesc tupdesc)
 			IPAddr.S_un.S_addr = (u_long)ip_addr_table->table[iter].dwAddr;
 			char *ip_val = inet_ntoa(IPAddr);
 			memcpy((ip_rows + index), (int *)&val, sizeof(int));
-			memcpy((ip_rows + ip_index), (char *)ip_val, IP_ADDR_SIZE);
+			strlcpy((char *)(ip_rows + ip_index), ip_val, IP_ADDR_SIZE);
 		}
 	}
 


### PR DESCRIPTION
  Summary

  - Replace usleep() with nanosleep() in linux/cpu_usage_info.c, linux/cpu_memory_by_process.c, darwin/cpu_usage_info.c, and darwin/cpu_memory_by_process.c — usleep() is obsolete (CWE-676) and has undefined interaction with SIGALRM and other
  timer functions.
  - Replace unsafe memcpy/strncpy with strlcpy in linux/cpu_info.c, linux/cpu_memory_by_process.c, and darwin/cpu_memory_by_process.c — source buffers (getline() output, p_comm[17]) could exceed destination buffer sizes, risking buffer overflow
  (CWE-120).
  - Fix unbounded memcpy in linux/os_info.c — copy size was computed from getline() output (unbounded) into a char[MAXPGPATH] buffer; replaced with strlcpy(..., MAXPGPATH).
  - Fix source over-read in windows/network_info.c — memcpy was reading IP_ADDR_SIZE (20) bytes from inet_ntoa()'s static buffer (max 16 bytes); replaced with strlcpy.
  - Fix null pointer dereference in linux/cpu_info.c — strlen() was called on the result of strstr() without a prior NULL check (CWE-476).

  Test plan

  - Built successfully with zero errors/warnings on Ubuntu 24.04 (PostgreSQL 16, GCC + Clang)
  - Built successfully with zero errors/warnings on AlmaLinux 10 (PostgreSQL 16 PGDG, GCC + Clang)
  - All 9 extension functions verified working via CREATE EXTENSION system_stats and live queries on both platforms