### PR TITLE
fix(extension): allow v4.1 to show in extension list

### DIFF
--- a/system_stats--4.0--4.1.sql
+++ b/system_stats--4.0--4.1.sql
@@ -1,0 +1,1 @@
+-- No function has changed

--- a/system_stats.control
+++ b/system_stats.control
@@ -1,5 +1,5 @@
 # system_stats extension
 comment = 'EnterpriseDB system statistics for PostgreSQL'
-default_version = '4.0'
+default_version = '4.1'
 module_pathname = '$libdir/system_stats'
 relocatable = true


### PR DESCRIPTION
Fixes #69

Allows correct version to show in extension list after `ALTER EXTENSION system_stats UPDATE;`

```
pgtest_dev=# \dx system_stats
                          List of installed extensions
     Name     | Version | Schema |                  Description
--------------+---------+--------+-----------------------------------------------
 system_stats | 4.0     | public | EnterpriseDB system statistics for PostgreSQL
(1 row)

pgtest_dev=# ALTER EXTENSION system_stats UPDATE;
ALTER EXTENSION
pgtest_dev=# \dx system_stats
                          List of installed extensions
     Name     | Version | Schema |                  Description
--------------+---------+--------+-----------------------------------------------
 system_stats | 4.1     | public | EnterpriseDB system statistics for PostgreSQL
(1 row)
```

Also works on new creation:

```
pgtest_dev=# DROP EXTENSION system_stats;
DROP EXTENSION
pgtest_dev=# \dx system_stats
     List of installed extensions
 Name | Version | Schema | Description
------+---------+--------+-------------
(0 rows)

pgtest_dev=# CREATE EXTENSION system_stats;
CREATE EXTENSION
pgtest_dev=# \dx system_stats
                          List of installed extensions
     Name     | Version | Schema |                  Description
--------------+---------+--------+-----------------------------------------------
 system_stats | 4.1     | public | EnterpriseDB system statistics for PostgreSQL
(1 row)
```